### PR TITLE
feat: add server host to chart tooltips

### DIFF
--- a/internal/database/migrations/postgres/007_add_server_host_postgres.sql
+++ b/internal/database/migrations/postgres/007_add_server_host_postgres.sql
@@ -1,0 +1,1 @@
+ALTER TABLE speed_tests ADD COLUMN server_host TEXT; 

--- a/internal/database/migrations/sqlite/007_add_server_host.sql
+++ b/internal/database/migrations/sqlite/007_add_server_host.sql
@@ -1,0 +1,1 @@
+ALTER TABLE speed_tests ADD COLUMN server_host TEXT; 

--- a/internal/database/speedtest.go
+++ b/internal/database/speedtest.go
@@ -17,6 +17,7 @@ func (s *service) SaveSpeedTest(ctx context.Context, result types.SpeedTestResul
 	data := map[string]interface{}{
 		"server_name":    result.ServerName,
 		"server_id":      result.ServerID,
+		"server_host":    result.ServerHost,
 		"test_type":      result.TestType,
 		"download_speed": result.DownloadSpeed,
 		"upload_speed":   result.UploadSpeed,
@@ -107,6 +108,7 @@ func (s *service) GetSpeedTests(ctx context.Context, timeRange string, page, lim
 		"id",
 		"server_name",
 		"server_id",
+		"server_host",
 		"test_type",
 		"download_speed",
 		"upload_speed",
@@ -133,6 +135,7 @@ func (s *service) GetSpeedTests(ctx context.Context, timeRange string, page, lim
 			&result.ID,
 			&result.ServerName,
 			&result.ServerID,
+			&result.ServerHost,
 			&result.TestType,
 			&result.DownloadSpeed,
 			&result.UploadSpeed,

--- a/internal/speedtest/librespeed.go
+++ b/internal/speedtest/librespeed.go
@@ -136,6 +136,7 @@ func (s *service) RunLibrespeedTest(ctx context.Context, opts *types.TestOptions
 	dbResult, err := s.db.SaveSpeedTest(ctx, types.SpeedTestResult{
 		ServerName:    result.Server,
 		ServerID:      fmt.Sprintf("librespeed-%s", librespeedResult.Server.URL),
+		ServerHost:    &librespeedResult.Server.URL,
 		TestType:      "librespeed",
 		DownloadSpeed: result.DownloadSpeed,
 		UploadSpeed:   result.UploadSpeed,

--- a/internal/speedtest/speedtest.go
+++ b/internal/speedtest/speedtest.go
@@ -127,6 +127,7 @@ func (s *service) RunTest(ctx context.Context, opts *types.TestOptions) (*Result
 		dbResult, err := s.db.SaveSpeedTest(context.Background(), types.SpeedTestResult{
 			ServerName:    opts.ServerHost,
 			ServerID:      fmt.Sprintf("iperf3-%s", opts.ServerHost),
+			ServerHost:    &opts.ServerHost,
 			TestType:      "iperf3",
 			DownloadSpeed: downloadSpeed,
 			UploadSpeed:   uploadSpeed,
@@ -354,6 +355,7 @@ func (s *service) RunTest(ctx context.Context, opts *types.TestOptions) (*Result
 	dbResult, err := s.db.SaveSpeedTest(context.Background(), types.SpeedTestResult{
 		ServerName:    selectedServer.Name,
 		ServerID:      selectedServer.ID,
+		ServerHost:    &selectedServer.Host,
 		TestType:      "speedtest",
 		DownloadSpeed: result.DownloadSpeed,
 		UploadSpeed:   result.UploadSpeed,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -41,6 +41,7 @@ type SpeedTestResult struct {
 	ID            int64     `json:"id"`
 	ServerName    string    `json:"serverName"`
 	ServerID      string    `json:"serverId"`
+	ServerHost    *string   `json:"serverHost,omitempty"`
 	TestType      string    `json:"testType"`
 	DownloadSpeed float64   `json:"downloadSpeed"`
 	UploadSpeed   float64   `json:"uploadSpeed"`

--- a/web/src/components/speedtest/SpeedHistoryChart.tsx
+++ b/web/src/components/speedtest/SpeedHistoryChart.tsx
@@ -160,6 +160,9 @@ export const SpeedHistoryChart: React.FC<SpeedHistoryChartProps> = ({
         upload: Number(item.uploadSpeed) || 0,
         latency: Number(parseFloat(item.latency?.replace("ms", "")) || 0),
         jitter: Number(item.jitter) || 0,
+        serverName: item.serverName || "Unknown Server",
+        serverHost: item.serverHost || item.serverName || "Unknown Server",
+        testType: item.testType || "speedtest",
       }))
       .filter(
         (item) =>
@@ -312,6 +315,49 @@ export const SpeedHistoryChart: React.FC<SpeedHistoryChartProps> = ({
                 return [`${value.toFixed(isMobile ? 1 : 2)} Mbps`, name];
               }
               return [`${value.toFixed(isMobile ? 1 : 2)} ms`, name];
+            }}
+            labelFormatter={(label, payload) => {
+              if (payload && payload.length > 0) {
+                const data = payload[0].payload;
+                const shouldRedact =
+                  isPublic &&
+                  (data.testType === "iperf3" ||
+                    data.testType === "librespeed");
+
+                return (
+                  <div>
+                    <div>{label}</div>
+                    <div
+                      style={{
+                        color: "#60A5FA",
+                        fontSize: isMobile ? "11px" : "12px",
+                        marginTop: "4px",
+                        fontWeight: "500",
+                      }}
+                    >
+                      {shouldRedact
+                        ? "redacted host"
+                        : data.serverHost || data.serverName}
+                      {data.testType && (
+                        <span
+                          style={{
+                            color: "#9CA3AF",
+                            fontSize: isMobile ? "10px" : "11px",
+                            marginLeft: "8px",
+                          }}
+                        >
+                          (
+                          {data.testType === "speedtest"
+                            ? "speedtest.net"
+                            : data.testType}
+                          )
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              }
+              return label;
             }}
           />
           {visibleMetrics.download && (


### PR DESCRIPTION
- Add ServerHost field to SpeedTestResult struct as nullable pointer
- Create database migrations for server_host column
- Store actual server URLs/hosts for all test types:
  - speedtest.net: actual server URL from selectedServer.Host
  - iperf3: host:port that was tested
  - librespeed: server URL from librespeed result
- Update chart tooltips to show server URLs
- Add privacy protection: show "redacted host" for iperf/librespeed on /public endpoint
- Graceful fallback to server name for existing records without host data
![CleanShot 2025-06-27 at 00 26 41@2x](https://github.com/user-attachments/assets/646e1e69-8671-4876-922c-c2360f8776a3)
