### PR TITLE
feat(web): standardize iperf3 server selection

### DIFF
--- a/web/src/components/speedtest/ScheduleManager.tsx
+++ b/web/src/components/speedtest/ScheduleManager.tsx
@@ -374,7 +374,7 @@ export default function ScheduleManager({
           if (server.isLibrespeed) {
             return (
               <span key={id}>
-                {server.sponsor} - {server.name} -{" "}
+                {server.name} -{" "}
                 <span className="text-blue-400 drop-shadow-[0_0_1px_rgba(96,165,250,0.8)]">
                   librespeed
                 </span>

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, Fragment } from "react";
 import { motion } from "motion/react";
 import {
   Radio,
@@ -16,9 +16,14 @@ import {
   ListboxButton,
   ListboxOptions,
   ListboxOption,
+  Dialog,
 } from "@headlessui/react";
 import { SavedIperfServer, Server } from "@/types/types";
-import { ChevronDownIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import {
+  ChevronDownIcon,
+  ChevronUpDownIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid";
 import { IperfServerModal } from "./IperfServerModal";
 import { getApiUrl } from "@/utils/baseUrl";
 
@@ -49,6 +54,9 @@ export const ServerList: React.FC<ServerListProps> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [filterCountry, setFilterCountry] = useState("");
   const [iperfHost, setIperfHost] = useState("");
+  const [iperfSearchTerm, setIperfSearchTerm] = useState("");
+  const [addServerModalOpen, setAddServerModalOpen] = useState(false);
+  const [iperfDisplayCount, setIperfDisplayCount] = useState(3);
   const [savedIperfServers, setSavedIperfServers] = useState<
     SavedIperfServer[]
   >([]);
@@ -88,6 +96,17 @@ export const ServerList: React.FC<ServerListProps> = ({
     return filtered.sort((a, b) => a.distance - b.distance);
   }, [servers, searchTerm, filterCountry]);
 
+  // Filter saved iperf servers
+  const filteredIperfServers = useMemo(() => {
+    return savedIperfServers.filter((server) => {
+      const matchesSearch =
+        iperfSearchTerm === "" ||
+        server.name.toLowerCase().includes(iperfSearchTerm.toLowerCase()) ||
+        server.host.toLowerCase().includes(iperfSearchTerm.toLowerCase());
+      return matchesSearch;
+    });
+  }, [savedIperfServers, iperfSearchTerm]);
+
   const handleServerSelect = (server: Server) => {
     onSelect(server);
   };
@@ -119,7 +138,9 @@ export const ServerList: React.FC<ServerListProps> = ({
     const response = await fetch(getApiUrl("/iperf/servers"));
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || "Failed to fetch saved iperf servers");
+      throw new Error(
+        errorData.message || "Failed to fetch saved iperf servers"
+      );
     }
     const data = await response.json();
     setSavedIperfServers(data);
@@ -305,170 +326,23 @@ export const ServerList: React.FC<ServerListProps> = ({
 
                   {testType === "iperf" && (
                     <div className="flex flex-col gap-4 mb-4">
-                      {/* Section for saved servers */}
-                      {savedIperfServers.length > 0 && (
-                        <div className="flex flex-col gap-2">
-                          <h3 className="text-sm font-medium text-gray-400">
-                            Saved Servers
-                          </h3>
-                          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
-                            <Listbox
-                              value=""
-                              onChange={(selectedServerId: string) => {
-                                const server = savedIperfServers.find(
-                                  (s) => s.id.toString() === selectedServerId
-                                );
-                                if (server) {
-                                  const iperfServer: Server = {
-                                    id: `iperf3-${server.host}:${server.port}`,
-                                    name: server.name,
-                                    host: `${server.host}:${server.port}`,
-                                    location: "Saved",
-                                    distance: 0,
-                                    country: "Saved",
-                                    sponsor: "Saved iperf3",
-                                    latitude: 0,
-                                    longitude: 0,
-                                    isIperf: true,
-                                  };
-                                  selectedServers.forEach((s) => onSelect(s));
-                                  onSelect(iperfServer);
-                                }
-                              }}
-                            >
-                              <div className="relative w-full sm:min-w-[200px] md:min-w-[300px] lg:min-w-[400px]">
-                                <ListboxButton className="relative w-full px-4 py-2 bg-gray-800/50 border border-gray-900 rounded-lg text-left text-gray-300 shadow-md focus:outline-none focus:ring-1 focus:ring-inset focus:ring-blue-500/50">
-                                  <span className="block truncate">
-                                    Select a server
-                                  </span>
-                                  <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                                    <ChevronUpDownIcon
-                                      className="h-5 w-5 text-gray-400"
-                                      aria-hidden="true"
-                                    />
-                                  </span>
-                                </ListboxButton>
-                                <Transition
-                                  enter="transition duration-100 ease-out"
-                                  enterFrom="transform scale-95 opacity-0"
-                                  enterTo="transform scale-100 opacity-100"
-                                  leave="transition duration-75 ease-out"
-                                  leaveFrom="transform scale-100 opacity-100"
-                                  leaveTo="transform scale-95 opacity-0"
-                                >
-                                  <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg bg-gray-800 border border-gray-900 py-1 shadow-lg focus:outline-none">
-                                    {savedIperfServers.map((server) => (
-                                      <ListboxOption
-                                        key={server.id}
-                                        value={server.id.toString()}
-                                        className={({ active }) =>
-                                          `relative cursor-pointer select-none py-2 px-4 ${
-                                            active
-                                              ? "bg-blue-500/10 text-blue-200"
-                                              : "text-gray-300"
-                                          }`
-                                        }
-                                      >
-                                        {({ selected }) => (
-                                          <div className="flex items-center justify-between space-x-2">
-                                            <div className="flex-1 min-w-0">
-                                              <span
-                                                className={`block truncate ${
-                                                  selected
-                                                    ? "font-medium"
-                                                    : "font-normal"
-                                                }`}
-                                              >
-                                                {server.name}
-                                              </span>
-                                              <span className="block truncate text-xs text-gray-400">
-                                                {server.host}:{server.port}
-                                              </span>
-                                            </div>
-                                            <button
-                                              onClick={(e) => {
-                                                e.stopPropagation();
-                                                setServerToDelete(server.id);
-                                                setDeleteModalOpen(true);
-                                              }}
-                                              className="px-2 py-1 text-sm text-red-400 hover:text-red-300 transition-colors"
-                                            >
-                                              Delete
-                                            </button>
-                                          </div>
-                                        )}
-                                      </ListboxOption>
-                                    ))}
-                                  </ListboxOptions>
-                                </Transition>
-                              </div>
-                            </Listbox>
-
-                            {selectedServers.length > 0 && (
-                              <div className="flex items-center gap-2 w-full sm:w-[300px] md:w-[400px] min-w-0">
-                                <div className="flex items-center gap-2 flex-1 min-w-0">
-                                  <span className="text-gray-400 text-sm whitespace-nowrap">
-                                    Selected:
-                                  </span>
-                                  <span
-                                    className="text-gray-300 text-sm truncate"
-                                    title={`${selectedServers[0].name} (${selectedServers[0].host})`}
-                                  >
-                                    {selectedServers[0].name}
-                                  </span>
-                                </div>
-                                <button
-                                  onClick={() =>
-                                    selectedServers.forEach((s) => onSelect(s))
-                                  }
-                                  className="px-2 py-1 text-sm text-gray-400 hover:text-gray-200 transition-colors shrink-0"
-                                >
-                                  ✕
-                                </button>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Section for adding new servers */}
-                      <div className="flex flex-col gap-2">
-                        <h3 className="text-sm font-medium text-gray-400">
-                          {savedIperfServers.length === 0
-                            ? "Add iperf3 Server"
-                            : "Add New Server"}
-                        </h3>
-                        <div className="flex gap-4">
+                      {/* Search Input and Add Button for iperf3 servers */}
+                      <div className="flex flex-col md:flex-row gap-4">
+                        <div className="flex-1">
                           <input
                             type="text"
-                            value={iperfHost}
-                            onChange={(e) => setIperfHost(e.target.value)}
-                            placeholder={
-                              window.innerWidth < 640
-                                ? "iperf.example.com:5201"
-                                : "Enter iperf3 server host (e.g., iperf.example.com:5201)"
-                            }
-                            className="flex-1 px-2 sm:px-4 py-1.5 sm:py-2 bg-gray-800/50 border border-gray-900 text-gray-300 rounded-lg text-xs sm:text-sm shadow-md"
+                            placeholder="Search saved servers..."
+                            className="w-full px-4 py-2 bg-gray-800/50 border border-gray-900 text-gray-300 rounded-lg shadow-md focus:outline-none focus:ring-1 focus:ring-inset focus:ring-blue-500/50"
+                            value={iperfSearchTerm}
+                            onChange={(e) => setIperfSearchTerm(e.target.value)}
                           />
-                          <button
-                            onClick={() => {
-                              const [host, portStr] = iperfHost.split(":");
-                              setNewServerDetails({
-                                host,
-                                port: portStr || "5201",
-                              });
-                              setSaveModalOpen(true);
-                            }}
-                            disabled={!iperfHost.trim()}
-                            className={`px-4 py-2 rounded-lg transition-colors border shadow-md ${
-                              !iperfHost.trim()
-                                ? "bg-gray-700 text-gray-400 cursor-not-allowed border-gray-900"
-                                : "bg-blue-500 hover:bg-blue-600 text-white border-blue-600 hover:border-blue-700"
-                            }`}
-                          >
-                            Save
-                          </button>
                         </div>
+                        <button
+                          onClick={() => setAddServerModalOpen(true)}
+                          className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors border border-blue-600 hover:border-blue-700 shadow-md"
+                        >
+                          Add Server
+                        </button>
                       </div>
                     </div>
                   )}
@@ -548,7 +422,111 @@ export const ServerList: React.FC<ServerListProps> = ({
                   )}
 
                   {/* Server Grid */}
-                  {(testType === "speedtest" || testType === "librespeed") && (
+                  {testType === "iperf" ? (
+                    <>
+                      {filteredIperfServers.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-12 px-4">
+                          <div className="text-center max-w-md">
+                            <div className="text-gray-400 text-lg mb-2">🔧</div>
+                            <h3 className="text-lg font-medium text-gray-300 mb-2">
+                              No iperf3 servers found
+                            </h3>
+                            <p className="text-gray-400 text-sm mb-4">
+                              Add your first iperf3 server using the input
+                              above. Enter the server address and port (e.g.,
+                              iperf.example.com:5201)
+                            </p>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                          {filteredIperfServers
+                            .slice(0, iperfDisplayCount)
+                            .map((server) => {
+                              const iperfServer: Server = {
+                                id: `iperf3-${server.host}:${server.port}`,
+                                name: server.name,
+                                host: `${server.host}:${server.port}`,
+                                location: "Saved",
+                                distance: 0,
+                                country: "Saved",
+                                sponsor: "iperf3",
+                                latitude: 0,
+                                longitude: 0,
+                                isIperf: true,
+                              };
+                              return (
+                                <motion.div
+                                  key={server.id}
+                                  initial={{ opacity: 0, y: 20 }}
+                                  animate={{ opacity: 1, y: 0 }}
+                                  transition={{ duration: 0.3 }}
+                                >
+                                  <button
+                                    onClick={() => {
+                                      selectedServers.forEach((s) =>
+                                        onSelect(s)
+                                      );
+                                      onSelect(iperfServer);
+                                    }}
+                                    className={`w-full p-4 rounded-lg text-left transition-colors relative ${
+                                      selectedServers.some(
+                                        (s) => s.id === iperfServer.id
+                                      )
+                                        ? "bg-blue-500/10 border-blue-400/50 shadow-lg"
+                                        : "bg-gray-800/50 border-gray-900 hover:bg-gray-800 shadow-lg"
+                                    } border`}
+                                  >
+                                    <div className="flex flex-col gap-1 pr-8">
+                                      <span className="text-blue-300 font-medium truncate">
+                                        {server.name}
+                                      </span>
+                                      <span className="text-gray-400 text-sm">
+                                        iperf3 Server
+                                        <span
+                                          className="block truncate text-xs"
+                                          title={`${server.host}:${server.port}`}
+                                        >
+                                          {server.host}:{server.port}
+                                        </span>
+                                      </span>
+                                      <span className="text-gray-400 text-sm mt-1">
+                                        Custom Server
+                                      </span>
+                                    </div>
+                                    <button
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setServerToDelete(server.id);
+                                        setDeleteModalOpen(true);
+                                      }}
+                                      className="absolute top-2 right-2 text-red-500 p-1 bg-red-900/50 border border-gray-900 rounded-md hover:bg-red-900/70 hover:text-red-400 transition-colors"
+                                      title="Delete server"
+                                    >
+                                      <XMarkIcon className="h-4 w-4" />
+                                    </button>
+                                  </button>
+                                </motion.div>
+                              );
+                            })}
+                        </div>
+                      )}
+
+                      {/* Load More Button for iperf3 */}
+                      {filteredIperfServers.length > iperfDisplayCount && (
+                        <div className="flex justify-center mt-6">
+                          <button
+                            onClick={() =>
+                              setIperfDisplayCount((prev) => prev + 6)
+                            }
+                            className="px-4 py-2 bg-gray-800/50 border border-gray-900/80 text-gray-300/50 hover:text-gray-300 rounded-lg hover:bg-gray-800 transition-colors"
+                          >
+                            Load More
+                          </button>
+                        </div>
+                      )}
+                    </>
+                  ) : (
                     <>
                       {filteredServers.length === 0 &&
                       testType === "librespeed" ? (
@@ -634,7 +612,7 @@ export const ServerList: React.FC<ServerListProps> = ({
                   )}
 
                   {/* Load More Button */}
-                  {(testType === "speedtest" || testType === "librespeed") &&
+                  {testType !== "iperf" &&
                     filteredServers.length > displayCount && (
                       <div className="flex justify-center mt-6">
                         <button
@@ -686,6 +664,14 @@ export const ServerList: React.FC<ServerListProps> = ({
               confirmText="Save"
               serverDetails={newServerDetails}
             />
+
+            <AddServerModal
+              isOpen={addServerModalOpen}
+              onClose={() => setAddServerModalOpen(false)}
+              onConfirm={(name, host, port) => {
+                saveIperfServer(name, host, parseInt(port));
+              }}
+            />
           </div>
         );
       }}
@@ -716,3 +702,148 @@ const RadioOption: React.FC<{
     )}
   </Radio>
 );
+
+interface AddServerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, host: string, port: string) => void;
+}
+
+const AddServerModal: React.FC<AddServerModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+}) => {
+  const [serverName, setServerName] = useState("");
+  const [serverHost, setServerHost] = useState("");
+  const [serverPort, setServerPort] = useState("5201");
+
+  const handleClose = () => {
+    setServerName("");
+    setServerHost("");
+    setServerPort("5201");
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    if (serverName.trim() && serverHost.trim()) {
+      onConfirm(serverName.trim(), serverHost.trim(), serverPort.trim());
+      handleClose();
+    }
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-xl bg-gray-850/95 border border-gray-900 p-6 shadow-xl transition-all">
+                <Dialog.Title
+                  as="h2"
+                  className="text-xl font-semibold text-white mb-4"
+                >
+                  Add iperf3 Server
+                </Dialog.Title>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="serverName"
+                      className="block text-sm font-medium text-gray-400"
+                    >
+                      Server Name
+                    </label>
+                    <input
+                      type="text"
+                      id="serverName"
+                      value={serverName}
+                      onChange={(e) => setServerName(e.target.value)}
+                      placeholder="Enter a name for this server"
+                      className="w-full px-4 py-2 bg-gray-800/50 border border-gray-900 text-gray-300 rounded-lg shadow-md focus:outline-none focus:ring-1 focus:ring-inset focus:ring-blue-500/50"
+                      autoFocus
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="serverHost"
+                      className="block text-sm font-medium text-gray-400"
+                    >
+                      Server Host
+                    </label>
+                    <input
+                      type="text"
+                      id="serverHost"
+                      value={serverHost}
+                      onChange={(e) => setServerHost(e.target.value)}
+                      placeholder="iperf.example.com"
+                      className="w-full px-4 py-2 bg-gray-800/50 border border-gray-900 text-gray-300 rounded-lg shadow-md focus:outline-none focus:ring-1 focus:ring-inset focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="serverPort"
+                      className="block text-sm font-medium text-gray-400"
+                    >
+                      Server Port
+                    </label>
+                    <input
+                      type="number"
+                      id="serverPort"
+                      value={serverPort}
+                      onChange={(e) => setServerPort(e.target.value)}
+                      placeholder="5201"
+                      className="w-full px-4 py-2 bg-gray-800/50 border border-gray-900 text-gray-300 rounded-lg shadow-md focus:outline-none focus:ring-1 focus:ring-inset focus:ring-blue-500/50"
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-6 flex justify-end gap-3">
+                  <button
+                    type="button"
+                    className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+                    onClick={handleClose}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!serverName.trim() || !serverHost.trim()}
+                    className={`px-4 py-2 rounded-lg shadow-md transition-colors border text-sm ${
+                      !serverName.trim() || !serverHost.trim()
+                        ? "bg-gray-700 text-gray-400 cursor-not-allowed border-gray-900"
+                        : "bg-blue-500 hover:bg-blue-600 text-white border-blue-600 hover:border-blue-700"
+                    }`}
+                    onClick={handleConfirm}
+                  >
+                    Add Server
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -459,12 +459,9 @@ export const ServerList: React.FC<ServerListProps> = ({
                                   transition={{ duration: 0.3 }}
                                 >
                                   <button
-                                    onClick={() => {
-                                      selectedServers.forEach((s) =>
-                                        onSelect(s)
-                                      );
-                                      onSelect(iperfServer);
-                                    }}
+                                    onClick={() =>
+                                      handleServerSelect(iperfServer)
+                                    }
                                     className={`w-full p-4 rounded-lg text-left transition-colors relative ${
                                       selectedServers.some(
                                         (s) => s.id === iperfServer.id

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -53,7 +53,6 @@ export const ServerList: React.FC<ServerListProps> = ({
   const [displayCount, setDisplayCount] = useState(3);
   const [searchTerm, setSearchTerm] = useState("");
   const [filterCountry, setFilterCountry] = useState("");
-  const [iperfHost, setIperfHost] = useState("");
   const [iperfSearchTerm, setIperfSearchTerm] = useState("");
   const [addServerModalOpen, setAddServerModalOpen] = useState(false);
   const [iperfDisplayCount, setIperfDisplayCount] = useState(3);
@@ -160,9 +159,6 @@ export const ServerList: React.FC<ServerListProps> = ({
         const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.message || "Failed to save iperf server");
       }
-
-      // Clear the input after successful save
-      setIperfHost("");
 
       // Refresh the list of saved servers
       await fetchSavedIperfServers();
@@ -656,7 +652,6 @@ export const ServerList: React.FC<ServerListProps> = ({
                     newServerDetails.host,
                     parseInt(newServerDetails.port)
                   );
-                  setIperfHost("");
                 }
               }}
               title="Save Server"

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -213,7 +213,7 @@ export const ServerList: React.FC<ServerListProps> = ({
                   Server Selection
                 </h2>
                 <p className="text-gray-400 text-sm pl-1 pb-1">
-                  Choose between speedtest.net or iperf3 servers
+                  Choose between speedtest.net, iperf3 or librespeed servers
                 </p>
               </div>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
- Converted iperf3 server selection from dropdown to card-based grid layout matching speedtest.net
- Added search functionality for saved iperf3 servers
- Implemented modal-based server addition with name and host/port fields
- Added pagination with "Load More" button (3 initial, +6 increments)
- Standardized delete button styling to match ScheduleManager component