### PR TITLE
chore: add license headers to frontend source files

### DIFF
--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 "use client";
 import { cn } from "@/lib/utils";
 import React from "react";

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 

--- a/web/src/types/speedtest.ts
+++ b/web/src/types/speedtest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/baseUrl.ts
+++ b/web/src/utils/baseUrl.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 export function getBaseUrl(): string {
     // Get from window.__BASE_URL__ which will be set in index.html
     const baseUrl = window.__BASE_URL__;

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { TracerouteResult, TracerouteHop } from "@/types/types";
 
 export const filterTrailingTimeouts = (hops: TracerouteHop[]) => {

--- a/web/src/utils/timeUtils.ts
+++ b/web/src/utils/timeUtils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 export const formatNextRun = (dateString: string): string => {
   const date = new Date(dateString);
   const now = new Date();


### PR DESCRIPTION
Add GPL-2.0-or-later license headers to frontend TypeScript files and update existing headers to include 2025 copyright year.