### PR TITLE
fix: increase default ping interval to 1000ms for FreeBSD compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ udp_bandwidth = "100M"
 
 [speedtest.iperf.ping]
 count = 5
-interval = 200
+interval = 1000
 timeout = 10
 
 [geoip]
@@ -243,7 +243,7 @@ Example `librespeed-servers.json`:
 | `NETRONOME__IPERF_ENABLE_UDP`                 | Enable UDP mode for jitter testing                                | `false`                                      | No                     |
 | `NETRONOME__IPERF_UDP_BANDWIDTH`              | Bandwidth limit for UDP tests (e.g., "100M")                      | `100M`                                       | No                     |
 | `NETRONOME__IPERF_PING_COUNT`                 | Number of ping packets to send for iperf3 tests                   | `5`                                          | No                     |
-| `NETRONOME__IPERF_PING_INTERVAL`              | Interval between ping packets in milliseconds for iperf3 tests    | `200`                                        | No                     |
+| `NETRONOME__IPERF_PING_INTERVAL`              | Interval between ping packets in milliseconds for iperf3 tests    | `1000`                                       | No                     |
 | `NETRONOME__IPERF_PING_TIMEOUT`               | Timeout for ping tests in seconds for iperf3 tests                | `10`                                         | No                     |
 | `NETRONOME__SPEEDTEST_TIMEOUT`                | Speedtest timeout in seconds                                      | `30`                                         | No                     |
 | `NETRONOME__LOG_LEVEL`                        | Log level (`trace`/`debug`/`info`/`warn`/`error`/`fatal`/`panic`) | `info`                                       | No                     |

--- a/config.toml
+++ b/config.toml
@@ -41,7 +41,7 @@ udp_bandwidth = "100M"
 
 [speedtest.iperf.ping]
 count = 5
-interval = 200
+interval = 1000
 timeout = 10
 
 [speedtest.librespeed]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,7 +190,7 @@ func New() *Config {
 				UDPBandwidth:  "100M",
 				Ping: PingConfig{
 					Count:    5,
-					Interval: 200,
+					Interval: 1000,
 					Timeout:  10,
 				},
 			},


### PR DESCRIPTION
On FreeBSD, ping commands with intervals less than 1 second require  super-user privileges. The previous default of 200ms (0.2 seconds)  caused ping tests to fail with exit status 77.

This change updates the default ping interval to 1000ms (1 second)  to ensure compatibility across all platforms including FreeBSD.

Changes:
- Update default ping interval in config.go from 200ms to 1000ms
- Update example config.toml to reflect new default
- Update README documentation for ping interval defaults

Fixes #58