### PR TITLE
fix(notifications): only send notifications when thresholds are exceeded

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -47,10 +47,13 @@ func (n *Notifier) SendNotification(result *types.SpeedTestResult) {
 
 	alerts := n.checkThresholds(result)
 
-	payload := n.buildPayload(result, alerts)
+	// Only send notification if there are threshold breaches
+	if len(alerts) > 0 {
+		payload := n.buildPayload(result, alerts)
 
-	if err := n.sendWebhook(payload); err != nil {
-		log.Error().Err(err).Msg("Failed to send notification")
+		if err := n.sendWebhook(payload); err != nil {
+			log.Error().Err(err).Msg("Failed to send notification")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed bug where notifications were sent for every speed test regardless of threshold status
- Notifications are now only sent when at least one metric exceeds its configured threshold

## Problem
Users were receiving Discord/webhook notifications showing green "all good" results even when all metrics were within acceptable thresholds. For example, with thresholds set to:
- Ping: 20ms
- Download: 500 Mbps  
- Upload: 500 Mbps

A test with 18ms ping and 800+ Mbps speeds would still trigger a notification.

## Solution
Added a check to only send notifications when the `alerts` array contains threshold breaches. This ensures users only get notified when action might be needed.

## Test plan
- [x] Configure speed test notifications with reasonable thresholds
- [x] Run a speed test that meets all thresholds - verify NO notification is sent
- [x] Run a speed test that breaches at least one threshold - verify notification IS sent with alert details

🤖 Generated with [Claude Code](https://claude.ai/code)