### PR TITLE
fix: packet loss monitor scheduling updates on creation and manual start

### DIFF
--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -192,6 +192,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	// Set the broadcaster for packet loss service
 	if packetLossService != nil {
 		packetLossService.SetBroadcast(serverHandler.BroadcastPacketLossUpdate)
+		packetLossService.SetScheduler(schedulerSvc)
 
 		// Don't start monitors here - let the scheduler handle them
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -220,7 +220,7 @@ func (s *Server) RegisterRoutes() {
 
 			// Packet Loss monitoring routes
 			if s.packetLossService != nil {
-				packetLossHandler := handlers.NewPacketLossHandler(s.db, s.packetLossService)
+				packetLossHandler := handlers.NewPacketLossHandler(s.db, s.packetLossService, s.scheduler)
 				protected.GET("/packetloss/monitors", packetLossHandler.GetMonitors)
 				protected.POST("/packetloss/monitors", packetLossHandler.CreateMonitor)
 				protected.PUT("/packetloss/monitors/:id", packetLossHandler.UpdateMonitor)


### PR DESCRIPTION
- Set initial next_run time when creating new monitors
- Update last_run and next_run after manual test completion
- Add public methods to scheduler for external schedule updates
- Ensure monitors are immediately schedulable without restart

🤖 Generated with [Claude Code](https://claude.ai/code)