### PR TITLE
feat: allow toggling monitoring for Tailscale auto-discovered agents

### DIFF
--- a/web/src/components/monitor/MonitorAgentList.tsx
+++ b/web/src/components/monitor/MonitorAgentList.tsx
@@ -334,18 +334,16 @@ const AgentListItem: React.FC<AgentListItemProps> = ({
                 <SparklesIcon className="w-3.5 h-3.5" />
               )}
             </button>
-            {!(agent.discoveredAt && agent.isTailscale) && (
-              <button
-                className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit();
-                }}
-                title="Edit Agent"
-              >
-                <PencilIcon className="w-3.5 h-3.5" />
-              </button>
-            )}
+            <button
+              className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              title="Edit Agent"
+            >
+              <PencilIcon className="w-3.5 h-3.5" />
+            </button>
             <button
               className="p-1 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-200 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
               onClick={(e) => {

--- a/web/src/components/monitor/MonitorTab.tsx
+++ b/web/src/components/monitor/MonitorTab.tsx
@@ -232,18 +232,15 @@ export const MonitorTab: React.FC = () => {
                 )}
               </div>
               <div className="flex gap-2">
-                {/* Only show edit button for non-autodiscovered agents */}
-                {!(selectedAgent.discoveredAt && selectedAgent.isTailscale) && (
-                  <motion.button
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => handleEditAgent(selectedAgent)}
-                    className="p-2 bg-gray-200/50 dark:bg-gray-800/50 border border-gray-300 dark:border-gray-800 hover:bg-gray-300/50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg shadow-md transition-colors"
-                    title="Edit agent"
-                  >
-                    <PencilIcon className="h-4 w-4" />
-                  </motion.button>
-                )}
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => handleEditAgent(selectedAgent)}
+                  className="p-2 bg-gray-200/50 dark:bg-gray-800/50 border border-gray-300 dark:border-gray-800 hover:bg-gray-300/50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg shadow-md transition-colors"
+                  title="Edit agent"
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </motion.button>
                 <motion.button
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
- Enable edit button for all agents including Tailscale auto-discovered ones
- Make agent name and URL fields read-only for Tailscale agents in form
- Hide API key section entirely for Tailscale agents
- Update dialog title to 'Edit Monitoring Settings' for Tailscale agents
- Preserve Tailscale properties (isTailscale, tailscaleHostname, discoveredAt) on update
- Add informative message explaining limited editing capabilities

This allows users to enable/disable monitoring for auto-discovered agents while protecting their connection details from accidental modification.