### PR TITLE
fix: handle OIDC authentication with and without session_secret

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -73,8 +73,8 @@ function AuthRoute() {
         const status = await checkRegistrationStatus();
         console.log("AuthRoute: Status received:", status);
 
-        if (!status.hasUsers) {
-          console.log("AuthRoute: No users found, redirecting...");
+        if (!status.hasUsers && !status.oidcEnabled) {
+          console.log("AuthRoute: No users found and OIDC not enabled, redirecting...");
           navigate({ to: "/register" });
         }
       } catch (err) {


### PR DESCRIPTION
Fixed OIDC authentication to work correctly regardless of session_secret configuration:
- Extract JWT tokens properly whether they have mem_ prefix or are signed
- Check OIDC tokens before falling back to database user validation
- Support both memory-only sessions (no secret) and signed sessions (with secret)
- Fix frontend redirect logic to allow OIDC when no local users exist

This ensures OIDC users can authenticate in all configurations without requiring local database users.