### PR TITLE
fix: zombie MTR processes and frontend monitor toggling issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,8 @@ RUN export GOOS=$TARGETOS; \
 # build runner
 FROM alpine:latest
 
-
-# Install dependencies
-RUN apk add --no-cache sqlite iperf3 traceroute mtr tzdata
+# Install dependencies including tini for proper process reaping
+RUN apk add --no-cache tini sqlite iperf3 traceroute mtr tzdata
 
 ENV HOME="/data" \
     XDG_CONFIG_HOME="/data" \
@@ -105,5 +104,6 @@ RUN addgroup -S netronome && \
 
 USER netronome
 
-ENTRYPOINT ["netronome"]
+# Use tini as PID 1 to handle zombie process reaping
+ENTRYPOINT ["/sbin/tini", "--", "netronome"]
 CMD ["serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN export GOOS=$TARGETOS; \
     -o /app/netronome ./cmd/netronome
 
 # build runner
-FROM alpine:latest
+FROM alpine:3.22
 
 # Install dependencies including tini for proper process reaping
 RUN apk add --no-cache tini sqlite iperf3 traceroute mtr tzdata

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -78,11 +78,11 @@ RUN --network=none --mount=target=. \
     -X 'main.buildTime=${BUILDTIME}'" \
     -o /app/netronome ./cmd/netronome
 
-FROM alpine:latest
+FROM alpine:3.22
 
 LABEL org.opencontainers.image.source="https://github.com/autobrr/netronome"
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
-LABEL org.opencontainers.image.base.name="alpine:latest"
+LABEL org.opencontainers.image.base.name="alpine:3.22"
 
 # Install dependencies including tini for proper process reaping
 RUN apk add --no-cache tini sqlite iperf3 traceroute mtr tzdata

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -84,7 +84,8 @@ LABEL org.opencontainers.image.source="https://github.com/autobrr/netronome"
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
 LABEL org.opencontainers.image.base.name="alpine:latest"
 
-RUN apk add --no-cache sqlite iperf3 traceroute mtr tzdata
+# Install dependencies including tini for proper process reaping
+RUN apk add --no-cache tini sqlite iperf3 traceroute mtr tzdata
 
 ENV HOME="/data" \
     XDG_CONFIG_HOME="/data" \
@@ -105,5 +106,6 @@ RUN addgroup -S netronome && \
 
 USER netronome
 
-ENTRYPOINT ["netronome"]
+# Use tini as PID 1 to handle zombie process reaping
+ENTRYPOINT ["/sbin/tini", "--", "netronome"]
 CMD ["serve"]

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -191,8 +191,7 @@ var testTablesToClear = []string{
 	"speed_tests",
 	"saved_iperf_servers",
 	"users",
-	"registration_status",
-	// Keep: notification_events, notification_categories, schema_migrations
+	// Keep: notification_events, notification_categories, schema_migrations, registration_status
 }
 
 // cleanTestData removes all test data but keeps schema and seed data

--- a/internal/database/monitor_data.go
+++ b/internal/database/monitor_data.go
@@ -52,7 +52,7 @@ func (s *service) UpsertMonitorSystemInfo(ctx context.Context, agentID int64, in
 		update = update.Set("vnstat_version", info.VnstatVersion)
 		hasUpdates = true
 	}
-	if info.AgentVersion != "" {
+	if info.AgentVersion != nil && *info.AgentVersion != "" {
 		update = update.Set("agent_version", info.AgentVersion)
 		hasUpdates = true
 	}

--- a/internal/database/monitor_integration_test.go
+++ b/internal/database/monitor_integration_test.go
@@ -139,11 +139,12 @@ func TestMonitorAgent_SystemInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create system info
+		agentVersion := "1.0.0"
 		sysInfo := &types.MonitorSystemInfo{
 			Hostname:      "test-host",
 			Kernel:        "Linux 5.15.0 x86_64",
 			VnstatVersion: "2.10",
-			AgentVersion:  "1.0.0",
+			AgentVersion:  &agentVersion,
 			CPUModel:      "Intel Core i7",
 			CPUCores:      4,
 			CPUThreads:    8,

--- a/internal/database/packetloss_integration_test.go
+++ b/internal/database/packetloss_integration_test.go
@@ -264,7 +264,7 @@ func TestPacketLossMonitor_NotFound(t *testing.T) {
 		// Try to delete non-existent monitor
 		_ = td.Service.DeletePacketLossMonitor(99999)
 		// Deletion might not return error for non-existent records
-		// depending on implementation
+		// depending on implementation, so we explicitly ignore it
 	})
 }
 

--- a/internal/monitor/client.go
+++ b/internal/monitor/client.go
@@ -772,7 +772,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 		Hostname:      systemInfo.Hostname,
 		Kernel:        systemInfo.Kernel,
 		VnstatVersion: systemInfo.VnstatVersion,
-		AgentVersion:  agentVersion,
+		AgentVersion:  &agentVersion,
 	}
 
 	if err := s.db.UpsertMonitorSystemInfo(client.ctx, client.agent.ID, sysInfo); err != nil {

--- a/internal/speedtest/mtr_unix.go
+++ b/internal/speedtest/mtr_unix.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build !windows
+
+package speedtest
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureMTRCommand sets Unix-specific attributes for the MTR command
+func configureMTRCommand(cmd *exec.Cmd) {
+	// Set process group to ensure child processes are killed
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+// killMTRProcessGroup kills the process group for the MTR command
+func killMTRProcessGroup(pid int) error {
+	// Send SIGKILL to the process group (negative PID)
+	return syscall.Kill(-pid, syscall.SIGKILL)
+}

--- a/internal/speedtest/mtr_unix.go
+++ b/internal/speedtest/mtr_unix.go
@@ -13,6 +13,7 @@ import (
 // configureMTRCommand sets Unix-specific attributes for the MTR command
 func configureMTRCommand(cmd *exec.Cmd) {
 	// Set process group to ensure child processes are killed
+	// This is important even in containers to manage child processes
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}

--- a/internal/speedtest/mtr_windows.go
+++ b/internal/speedtest/mtr_windows.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package speedtest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureMTRCommand sets Windows-specific attributes for the MTR command
+func configureMTRCommand(cmd *exec.Cmd) {
+	// On Windows, we use CREATE_NEW_PROCESS_GROUP to create a new process group
+	// This allows us to send signals to the entire group
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+// killMTRProcessGroup kills the process for the MTR command on Windows
+func killMTRProcessGroup(pid int) error {
+	// On Windows, we can use taskkill to kill the process tree
+	// The /T flag kills the process and all its children
+	// The /F flag forces termination
+	killCmd := exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprintf("%d", pid))
+	err := killCmd.Run()
+	
+	// If taskkill fails, fall back to os.Process.Kill
+	if err != nil {
+		process, findErr := os.FindProcess(pid)
+		if findErr != nil {
+			return findErr
+		}
+		return process.Kill()
+	}
+	
+	return nil
+}

--- a/internal/speedtest/packetloss.go
+++ b/internal/speedtest/packetloss.go
@@ -1052,6 +1052,12 @@ func (s *PacketLossService) runMTRTest(monitor *PacketLossMonitor) (*probing.Sta
 		// Configure platform-specific process attributes
 		configureMTRCommand(cmd)
 		
+		// Get stdout pipe BEFORE starting the command
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+		}
+		
 		// Start the command
 		if err := cmd.Start(); err != nil {
 			return nil, fmt.Errorf("failed to start MTR: %w", err)
@@ -1081,12 +1087,6 @@ func (s *PacketLossService) runMTRTest(monitor *PacketLossMonitor) (*probing.Sta
 		// Create channels for output and errors
 		outputChan := make(chan []byte, 1)
 		errChan := make(chan error, 1)
-		
-		// Get stdout pipe
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get stdout pipe: %w", err)
-		}
 		
 		// Run command in goroutine
 		go func() {

--- a/internal/speedtest/packetloss_mtr_test.go
+++ b/internal/speedtest/packetloss_mtr_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package speedtest
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMTRProcessCleanup(t *testing.T) {
+	// Skip if MTR is not available
+	if _, err := exec.LookPath("mtr"); err != nil {
+		t.Skip("MTR not found, skipping test")
+	}
+
+	// Skip if not running as root/admin (MTR usually requires privileges)
+	if os.Geteuid() != 0 && runtime.GOOS != "windows" {
+		t.Skip("Test requires root privileges to run MTR")
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Test that we can start and kill MTR without leaving zombies
+	args := []string{
+		"-4",
+		"-j",
+		"-c", "100", // High count to ensure it runs long enough
+		"-i", "0.1", // Fast interval
+		"--no-dns",
+		"127.0.0.1",
+	}
+
+	// Create the command
+	cmd := exec.CommandContext(ctx, "mtr", args...)
+	configureMTRCommand(cmd)
+
+	// Start the command
+	err := cmd.Start()
+	if err != nil {
+		// If we can't start MTR even with privileges, skip
+		t.Skipf("Cannot start MTR: %v", err)
+	}
+
+	// Get the PID for cleanup tracking
+	pid := cmd.Process.Pid
+
+	// Let it run for a bit
+	time.Sleep(1 * time.Second)
+
+	// Kill the process group
+	err = killMTRProcessGroup(pid)
+	assert.NoError(t, err, "Failed to kill MTR process group")
+
+	// Wait for cleanup
+	time.Sleep(500 * time.Millisecond)
+
+	// Check that no zombie processes exist
+	hasZombies := checkForZombies()
+	assert.False(t, hasZombies, "Found zombie MTR processes after cleanup")
+}
+
+// TestProcessCleanupMechanism tests the cleanup mechanism with a simpler command
+func TestProcessCleanupMechanism(t *testing.T) {
+	// Use a simple long-running command that doesn't require privileges
+	var cmdName string
+	var args []string
+	
+	switch runtime.GOOS {
+	case "windows":
+		cmdName = "ping"
+		args = []string{"-n", "100", "127.0.0.1"}
+	default:
+		cmdName = "sleep"
+		args = []string{"100"}
+	}
+
+	// Create context with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Create the command
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+	configureMTRCommand(cmd)
+
+	// Start the command
+	err := cmd.Start()
+	require.NoError(t, err, "Failed to start test command")
+
+	// Get the PID
+	pid := cmd.Process.Pid
+
+	// Create a done channel
+	done := make(chan error, 1)
+
+	// Wait for command in goroutine
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	// Wait for timeout
+	select {
+	case <-ctx.Done():
+		// Context timeout - kill the process group
+		err := killMTRProcessGroup(pid)
+		// It's OK if the process is already gone (no such process error)
+		if err != nil && !isNoSuchProcessError(err) {
+			assert.NoError(t, err, "Failed to kill process group")
+		}
+	case <-done:
+		t.Fatal("Command should have been killed by timeout")
+	}
+
+	// Verify process is gone
+	time.Sleep(100 * time.Millisecond)
+	
+	// Try to find the process
+	if runtime.GOOS != "windows" {
+		// On Unix, check if process exists
+		process, err := os.FindProcess(pid)
+		if err == nil {
+			// Send signal 0 to check if process is alive
+			err = process.Signal(os.Signal(nil))
+			assert.Error(t, err, "Process should be dead")
+		}
+	}
+}
+
+// checkForZombies checks for zombie mtr processes
+func checkForZombies() bool {
+	if runtime.GOOS == "windows" {
+		// Windows doesn't have zombie processes in the same way
+		return false
+	}
+
+	// Run ps to check for zombie mtr processes
+	cmd := exec.Command("ps", "aux")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	
+	outputStr := string(output)
+	return containsZombieMTR(outputStr)
+}
+
+// containsZombieMTR checks if the ps output contains zombie mtr processes
+func containsZombieMTR(psOutput string) bool {
+	lines := splitLines(psOutput)
+	for _, line := range lines {
+		// Check for mtr process that is a zombie (defunct or Z state)
+		if containsString(line, "mtr") && 
+		   (containsString(line, "<defunct>") || containsString(line, " Z ")) {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper functions to avoid imports
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && stringIndex(s, substr) >= 0
+}
+
+func stringIndex(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// isNoSuchProcessError checks if the error is a "no such process" error
+func isNoSuchProcessError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return containsString(errStr, "no such process") || 
+	       containsString(errStr, "process already finished") ||
+	       containsString(errStr, "The process cannot be found")
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -331,7 +331,7 @@ type MonitorSystemInfo struct {
 	Hostname      string    `db:"hostname" json:"hostname"`
 	Kernel        string    `db:"kernel" json:"kernel"`
 	VnstatVersion string    `db:"vnstat_version" json:"vnstatVersion"`
-	AgentVersion  string    `db:"agent_version" json:"agentVersion"`
+	AgentVersion  *string   `db:"agent_version" json:"agentVersion"`
 	CPUModel      string    `db:"cpu_model" json:"cpuModel"`
 	CPUCores      int       `db:"cpu_cores" json:"cpuCores"`
 	CPUThreads    int       `db:"cpu_threads" json:"cpuThreads"`

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
@@ -214,7 +214,7 @@ interface PacketLossMonitorListProps {
   onDelete: (monitorId: number) => void;
   onToggle: (monitorId: number, enabled: boolean) => void;
   isLoading: boolean;
-  togglingMonitorId?: number | null;
+  togglingMonitorIds?: Set<number>;
 }
 
 export const PacketLossMonitorList: React.FC<PacketLossMonitorListProps> = ({
@@ -226,7 +226,7 @@ export const PacketLossMonitorList: React.FC<PacketLossMonitorListProps> = ({
   onDelete,
   onToggle,
   isLoading,
-  togglingMonitorId = null,
+  togglingMonitorIds = new Set(),
 }) => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [monitorToDelete, setMonitorToDelete] =
@@ -323,7 +323,7 @@ export const PacketLossMonitorList: React.FC<PacketLossMonitorListProps> = ({
               <div className="flex items-center gap-1 ml-4">
                 <button
                   className={`p-1.5 rounded-md transition-colors duration-200 ${
-                    togglingMonitorId === monitor.id
+                    togglingMonitorIds.has(monitor.id)
                       ? "opacity-50 cursor-not-allowed"
                       : monitor.enabled
                       ? "hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-400"
@@ -333,10 +333,10 @@ export const PacketLossMonitorList: React.FC<PacketLossMonitorListProps> = ({
                     e.stopPropagation();
                     onToggle(monitor.id, !monitor.enabled);
                   }}
-                  disabled={togglingMonitorId === monitor.id}
+                  disabled={togglingMonitorIds.has(monitor.id)}
                   title={monitor.enabled ? "Stop Monitor" : "Start Monitor"}
                 >
-                  {togglingMonitorId === monitor.id ? (
+                  {togglingMonitorIds.has(monitor.id) ? (
                     <div className="w-3.5 h-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600 dark:border-gray-600 dark:border-t-gray-300" />
                   ) : monitor.enabled ? (
                     <StopIcon className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
- Add Tini to Docker images for proper zombie process reaping
- Implement process group management for reliable MTR cleanup
- Fix stdout pipe ordering to prevent hangs
- Fix frontend issue where multiple monitors couldn't show toggling state simultaneously
- Pin Alpine base image to version 3.22 for consistent builds

## Details
This PR addresses multiple issues:

### 1. Zombie MTR Processes (Critical Bug)
Docker-deployed Netronome was building up zombie MTR processes over time. Fixed by:
- **Tini integration**: Added to both Dockerfiles as PID 1 to handle zombie reaping
- **Process group management**: Ensures all child processes are properly terminated
- **Graceful error handling**: Handles ESRCH/EPERM errors when processes are already dead
- **Fixed race condition**: Corrected stdout pipe creation order to prevent hangs

### 2. Frontend Monitor Toggling
Starting a second monitor would stop the first monitor's spinner animation. Fixed by:
- Replacing single togglingMonitorId with a Set to track multiple monitors
- Each monitor's play/stop button now shows its own spinner independently

### 3. Docker Image Consistency
- Pinned Alpine base image to version 3.22 instead of using 'latest' tag
- Ensures reproducible builds and avoids unexpected changes

All changes work together to provide comprehensive protection against zombie processes in containerized environments and improve the user experience.

Fixes the critical zombie process accumulation bug reported in production Docker deployments.