### PR TITLE
fix: calculate schedule times using server timezone

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -171,6 +171,11 @@ func (s *Server) handleCreateSchedule(c *gin.Context) {
 		return
 	}
 
+	// Calculate next_run on the server side using server's timezone
+	now := time.Now()
+	nextRun := s.scheduler.CalculateNextRun(schedule.Interval, now)
+	schedule.NextRun = nextRun
+
 	createdSchedule, err := s.db.CreateSchedule(c.Request.Context(), schedule)
 	if err != nil {
 		log.Error().Err(err).
@@ -191,6 +196,11 @@ func (s *Server) handleUpdateSchedule(c *gin.Context) {
 		_ = c.Error(fmt.Errorf("invalid schedule data: %w", err))
 		return
 	}
+
+	// Calculate next_run on the server side using server's timezone
+	now := time.Now()
+	nextRun := s.scheduler.CalculateNextRun(schedule.Interval, now)
+	schedule.NextRun = nextRun
 
 	err := s.db.UpdateSchedule(c.Request.Context(), schedule)
 	if err != nil {

--- a/web/src/components/speedtest/ScheduleManager.tsx
+++ b/web/src/components/speedtest/ScheduleManager.tsx
@@ -261,7 +261,7 @@ export default function ScheduleManager({
       serverIds: selectedServers.map((s) => s.id),
       interval:
         scheduleType === "exact" ? `exact:${exactTimes.join(",")}` : interval,
-      nextRun: calculateNextRun(interval, scheduleType, exactTimes.join(",")),
+      // nextRun is now calculated server-side to use server timezone
       enabled,
       options: {
         enableDownload: true,
@@ -845,7 +845,7 @@ export default function ScheduleManager({
                                           Next run in:
                                         </span>{" "}
                                         <span className="font-medium text-blue-600 dark:text-blue-400">
-                                          {formatNextRun(schedule.nextRun)}
+                                          {schedule.nextRun ? formatNextRun(schedule.nextRun) : "Calculating..."}
                                         </span>
                                       </p>
                                     </div>

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -48,7 +48,7 @@ export interface Schedule {
   id?: number;
   serverIds: string[];
   interval: string;
-  nextRun: string;
+  nextRun?: string;
   enabled: boolean;
   options: {
     enableDownload: boolean;


### PR DESCRIPTION
- Move nextRun calculation from frontend to backend for accurate timezone handling
- Backend now calculates all schedule times using server's TZ environment variable
- Fix packet loss monitor update handler to recalculate nextRun when interval changes
- Make nextRun optional in TypeScript Schedule interface
- Handle undefined nextRun in UI with "Calculating..." placeholder

This ensures scheduled tests run at the correct time based on server timezone rather than browser timezone, fixing the issue where "2 PM" would be interpreted differently depending on user location.