### PR TITLE
refactor(rtt_graph) center around average rtt

### DIFF
--- a/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
@@ -161,7 +161,7 @@ export const MonitorPerformanceChart: React.FC<
               axisLine={false}
               tickLine={false}
               scale="linear"
-              domain={[0, 'dataMax + 1']}
+              domain={[0, 100]}
               label={{
                 value: "Packet Loss (%)",
                 angle: 90,

--- a/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
@@ -52,6 +52,28 @@ export const MonitorPerformanceChart: React.FC<
     return data;
   }, [historyList]);
 
+  // Calculate RTT statistics for better axis scaling
+  const rttStats = useMemo(() => {
+    if (chartData.length === 0) return null;
+    
+    const allRttValues = chartData.flatMap(d => [d.avgRtt, d.minRtt, d.maxRtt]).filter(v => v > 0);
+    if (allRttValues.length === 0) return null;
+    
+    const min = Math.min(...allRttValues);
+    const max = Math.max(...allRttValues);
+    const avg = allRttValues.reduce((sum, val) => sum + val, 0) / allRttValues.length;
+    
+    // Calculate a good range around the data
+    const range = max - min;
+    const padding = Math.max(range * 0.1, 5); // 10% padding or 5ms minimum
+    
+    return {
+      min: Math.max(0, min - padding),
+      max: max + padding,
+      avg
+    };
+  }, [chartData]);
+
   if (chartData.length === 0) {
     return null;
   }
@@ -65,6 +87,11 @@ export const MonitorPerformanceChart: React.FC<
         <div className="flex items-center justify-between">
           <p className="text-gray-600 dark:text-gray-400 text-xs">
             Last 30 tests • {chartData.length} data points
+            {rttStats && (
+              <span className="ml-2 text-blue-600 dark:text-blue-400">
+                • Avg RTT: {rttStats.avg.toFixed(1)}ms
+              </span>
+            )}
           </p>
           <div className="flex items-center gap-4 text-xs text-gray-600 dark:text-gray-400">
             <div className="flex items-center gap-1">
@@ -113,6 +140,9 @@ export const MonitorPerformanceChart: React.FC<
               fontSize={11}
               axisLine={false}
               tickLine={false}
+              scale="linear"
+              domain={rttStats ? [Math.floor(rttStats.min), Math.ceil(rttStats.max)] : ['dataMin', 'dataMax']}
+              allowDataOverflow={false}
               label={{
                 value: "RTT (ms)",
                 angle: -90,
@@ -130,6 +160,8 @@ export const MonitorPerformanceChart: React.FC<
               fontSize={11}
               axisLine={false}
               tickLine={false}
+              scale="linear"
+              domain={[0, 'dataMax + 1']}
               label={{
                 value: "Packet Loss (%)",
                 angle: 90,


### PR DESCRIPTION
before:
<img width="713" height="401" alt="Screenshot 2025-08-18 170334" src="https://github.com/user-attachments/assets/72fc6833-3280-4b64-af7f-d113aaa152b9" /> 
after:
<img width="731" height="408" alt="Screenshot 2025-08-18 171056" src="https://github.com/user-attachments/assets/7e6b70b5-c148-4be9-b406-0ebcfc88114e" />

.......

before:
<img width="718" height="406" alt="Screenshot 2025-08-18 170604" src="https://github.com/user-attachments/assets/272c9e10-add1-4aed-b477-f99563fd5e63" />
after:
<img width="711" height="405" alt="Screenshot 2025-08-18 171135" src="https://github.com/user-attachments/assets/b66f7fe8-bb2c-45e6-bd86-ae21c1aa6cf5" />
