### PR TITLE
fix(agent): exclude cache/buffers from Linux memory usage

### DIFF
--- a/internal/agent/bandwidth.go
+++ b/internal/agent/bandwidth.go
@@ -43,7 +43,7 @@ func (a *Agent) handleHistoricalExport(c *gin.Context) {
 	}
 
 	// Parse the JSON to add timezone information
-	var bandwidthData map[string]interface{}
+	var bandwidthData map[string]any
 	if err := json.Unmarshal(output, &bandwidthData); err != nil {
 		log.Error().Err(err).Msg("Failed to parse bandwidth data JSON")
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/internal/agent/hardware.go
+++ b/internal/agent/hardware.go
@@ -131,13 +131,13 @@ func (a *Agent) getHardwareStats() (*HardwareStats, error) {
 		stats.Memory.ZFSArc = zfsArcSize
 
 		// Calculate used memory
-		// On Linux, the Used field from gopsutil includes cache/buffers
-		// We need to be careful about how we calculate "used" memory
+		// On Linux, exclude cache/buffers from "used" memory since they can be freed
+		// Available already accounts for memory that can be reclaimed
 		if runtime.GOOS == "linux" {
-			// Linux calculation: Total - Free - Buffers - Cached
-			// This gives us the actual application memory usage
-			stats.Memory.Used = vmStat.Total - vmStat.Free
-			// The UsedPercent should reflect total used including cache/buffers
+			// Linux calculation: Total - Available
+			// This gives us the actual application memory usage (excluding cache/buffers)
+			stats.Memory.Used = vmStat.Total - vmStat.Available
+			// The UsedPercent should reflect application memory usage only
 			stats.Memory.UsedPercent = float64(stats.Memory.Used) / float64(vmStat.Total) * 100
 		} else {
 			// For other systems, use the provided values

--- a/internal/agent/hardware.go
+++ b/internal/agent/hardware.go
@@ -357,8 +357,8 @@ func getZFSARCSize() uint64 {
 	}
 
 	// Parse the arcstats file to find the size
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(data), "\n")
+	for line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) >= 3 && fields[0] == "size" {
 			size, err := strconv.ParseUint(fields[2], 10, 64)

--- a/internal/agent/system.go
+++ b/internal/agent/system.go
@@ -203,15 +203,15 @@ func (a *Agent) getSystemInfo() (*SystemInfo, error) {
 
 			// Get vnstat interface alias if configured
 			if output, err := exec.Command("vnstat", "--json", "-i", iface.Name).Output(); err == nil {
-				var interfaceData map[string]interface{}
+				var interfaceData map[string]any
 				if json.Unmarshal(output, &interfaceData) == nil {
-					if interfaces, ok := interfaceData["interfaces"].([]interface{}); ok && len(interfaces) > 0 {
-						if ifaceData, ok := interfaces[0].(map[string]interface{}); ok {
+					if interfaces, ok := interfaceData["interfaces"].([]any); ok && len(interfaces) > 0 {
+						if ifaceData, ok := interfaces[0].(map[string]any); ok {
 							if alias, ok := ifaceData["alias"].(string); ok {
 								ifaceInfo.Alias = alias
 							}
-							if traffic, ok := ifaceData["traffic"].(map[string]interface{}); ok {
-								if total, ok := traffic["total"].(map[string]interface{}); ok {
+							if traffic, ok := ifaceData["traffic"].(map[string]any); ok {
+								if total, ok := traffic["total"].(map[string]any); ok {
 									if rx, ok := total["rx"].(float64); ok {
 										if tx, ok := total["tx"].(float64); ok {
 											ifaceInfo.BytesTotal = int64(rx + tx)

--- a/internal/agent/tailscale.go
+++ b/internal/agent/tailscale.go
@@ -52,7 +52,7 @@ func (a *Agent) startWithTailscale(ctx context.Context) error {
 		Hostname:  hostname,
 		AuthKey:   a.tailscaleConfig.AuthKey,
 		Ephemeral: a.tailscaleConfig.Ephemeral,
-		Logf: func(format string, args ...interface{}) {
+		Logf: func(format string, args ...any) {
 			log.Debug().Msgf("[tsnet] "+format, args...)
 		},
 	}
@@ -204,16 +204,16 @@ func (a *Agent) startWithHostTailscale(ctx context.Context) error {
 }
 
 // GetTailscaleStatus returns the current Tailscale connection status
-func (a *Agent) GetTailscaleStatus() (map[string]interface{}, error) {
+func (a *Agent) GetTailscaleStatus() (map[string]any, error) {
 	if !a.useTailscale || a.tailscaleConfig == nil {
-		return map[string]interface{}{
+		return map[string]any{
 			"enabled": false,
 			"status":  "disabled",
 		}, nil
 	}
 
 	method, _ := a.tailscaleConfig.GetEffectiveMethod()
-	result := map[string]interface{}{
+	result := map[string]any{
 		"enabled": true,
 		"method":  method,
 	}


### PR DESCRIPTION
On Linux systems, cached and buffered memory can be reclaimed by
applications when needed, so it should not be counted as "used" memory.

Changes:
- Use Total - Available instead of Total - Free for Linux memory calculation
- Available already accounts for reclaimable cache/buffer memory
- Windows and macOS already handle this correctly via their platform APIs

Fixes #112