### PR TITLE
fix(notification): incorrect example for Pushover

### DIFF
--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -107,7 +107,7 @@ export const notificationsApi = {
 
   // Events
   getEvents: async (category?: string): Promise<NotificationEvent[]> => {
-    const url = category 
+    const url = category
       ? getApiUrl(`/notifications/events?category=${encodeURIComponent(category)}`)
       : getApiUrl("/notifications/events");
     const response = await fetch(url, {
@@ -208,7 +208,7 @@ export const SHOUTRRR_SERVICES = [
   { value: "ntfy", label: "ntfy", example: "ntfy://TOPIC@HOSTNAME" },
   { value: "opsgenie", label: "OpsGenie", example: "opsgenie://APIKEY" },
   { value: "pushbullet", label: "Pushbullet", example: "pushbullet://APIKEY" },
-  { value: "pushover", label: "Pushover", example: "pushover://TOKEN@USER" },
+  { value: "pushover", label: "Pushover", example: "pushover://:API_TOKEN@USER_KEY" },
   { value: "rocketchat", label: "Rocket.Chat", example: "rocketchat://HOSTNAME/TOKEN@CHANNEL" },
   { value: "slack", label: "Slack", example: "slack://TOKEN@CHANNEL" },
   { value: "teams", label: "Microsoft Teams", example: "teams://WEBHOOK_URL" },


### PR DESCRIPTION
It has been puzzling me for a day why the Pushover notification is not working. Then I found this bug report:
https://github.com/containrrr/shoutrrr/issues/466

This is not a typo, it really needs to be in this format:
`pushover://:API_TOKEN@USER_KEY`

I tested it just now and it works!