### PR TITLE
feat: auto-detect Tailscale agents based on IP/hostname patterns

### DIFF
--- a/internal/handlers/monitor.go
+++ b/internal/handlers/monitor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/autobrr/netronome/internal/database"
 	"github.com/autobrr/netronome/internal/monitor"
 	"github.com/autobrr/netronome/internal/types"
+	"github.com/autobrr/netronome/internal/utils"
 )
 
 // MonitorHandler handles monitoring endpoints
@@ -116,6 +117,12 @@ func (h *MonitorHandler) CreateAgent(c *gin.Context) {
 		}
 	}
 
+	// Auto-detect Tailscale agents based on URL (if not already set by discovery)
+	if !agent.IsTailscale && utils.IsTailscaleURL(agent.URL) {
+		agent.IsTailscale = true
+		log.Debug().Str("url", agent.URL).Msg("Auto-detected Tailscale agent based on URL")
+	}
+
 	// Create agent in database
 	createdAgent, err := h.db.CreateMonitorAgent(c.Request.Context(), &agent)
 	if err != nil {
@@ -173,11 +180,24 @@ func (h *MonitorHandler) UpdateAgent(c *gin.Context) {
 		agent.APIKey = existingAgent.APIKey
 	}
 
-	// Preserve Tailscale-specific fields that should never be modified
-	agent.IsTailscale = existingAgent.IsTailscale
+	// Preserve discovery-specific fields that should never be modified for auto-discovered agents
 	agent.TailscaleHostname = existingAgent.TailscaleHostname
 	agent.DiscoveredAt = existingAgent.DiscoveredAt
 	agent.Interface = existingAgent.Interface
+	
+	// Handle IsTailscale field: preserve if auto-discovered, otherwise auto-detect
+	if existingAgent.DiscoveredAt != nil {
+		// This was auto-discovered, preserve the Tailscale flag
+		agent.IsTailscale = existingAgent.IsTailscale
+	} else {
+		// This is a manually created agent, auto-detect based on URL
+		agent.IsTailscale = utils.IsTailscaleURL(agent.URL)
+		if agent.IsTailscale && !existingAgent.IsTailscale {
+			log.Debug().Str("url", agent.URL).Msg("Auto-detected Tailscale agent based on URL during update")
+		} else if !agent.IsTailscale && existingAgent.IsTailscale {
+			log.Debug().Str("url", agent.URL).Msg("Agent URL no longer appears to be Tailscale during update")
+		}
+	}
 
 	// Set the ID from URL
 	agent.ID = id

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -6,6 +6,9 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"net"
+	"net/url"
+	"strings"
 )
 
 func GenerateSecureToken(length int) (string, error) {
@@ -14,4 +17,70 @@ func GenerateSecureToken(length int) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(bytes), nil
+}
+
+// IsTailscaleIP checks if a given URL contains a Tailscale IP address
+func IsTailscaleIP(urlStr string) bool {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+
+	host := parsedURL.Hostname()
+	if host == "" {
+		return false
+	}
+
+	// Parse the IP address
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	// Check if it's in the Tailscale CGNAT range (100.64.0.0/10)
+	_, tailscaleNet, _ := net.ParseCIDR("100.64.0.0/10")
+	if tailscaleNet != nil && tailscaleNet.Contains(ip) {
+		return true
+	}
+
+	// Check if it's in the Tailscale IPv6 range (fd7a:115c:a1e0::/48)
+	_, tailscaleNet6, _ := net.ParseCIDR("fd7a:115c:a1e0::/48")
+	if tailscaleNet6 != nil && tailscaleNet6.Contains(ip) {
+		return true
+	}
+
+	return false
+}
+
+// IsTailscaleHostname checks if a hostname looks like a Tailscale MagicDNS name
+func IsTailscaleHostname(urlStr string) bool {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+
+	host := parsedURL.Hostname()
+	if host == "" {
+		return false
+	}
+
+	// Check for common Tailscale MagicDNS suffixes
+	tailscaleSuffixes := []string{
+		".ts.net",
+		".beta.tailscale.net",
+		".alpha.tailscale.net",
+	}
+
+	for _, suffix := range tailscaleSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsTailscaleURL checks if a URL is using Tailscale (either IP or hostname)
+func IsTailscaleURL(urlStr string) bool {
+	return IsTailscaleIP(urlStr) || IsTailscaleHostname(urlStr)
 }

--- a/internal/utils/tailscale_test.go
+++ b/internal/utils/tailscale_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package utils
+
+import "testing"
+
+func TestIsTailscaleIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "Tailscale CGNAT IPv4",
+			url:      "http://100.64.0.1:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Tailscale CGNAT IPv4 edge case",
+			url:      "http://100.127.255.255:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Tailscale IPv6",
+			url:      "http://[fd7a:115c:a1e0::1]:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Regular private IP",
+			url:      "http://192.168.1.100:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Public IP",
+			url:      "http://8.8.8.8:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Invalid IP range",
+			url:      "http://100.63.255.255:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Invalid URL",
+			url:      "not-a-url",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTailscaleIP(tt.url)
+			if result != tt.expected {
+				t.Errorf("IsTailscaleIP(%s) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsTailscaleHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "Tailscale MagicDNS .ts.net",
+			url:      "http://my-device.ts.net:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Tailscale MagicDNS beta",
+			url:      "http://my-device.beta.tailscale.net:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Tailscale MagicDNS alpha",
+			url:      "http://my-device.alpha.tailscale.net:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Regular hostname",
+			url:      "http://example.com:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Regular localhost",
+			url:      "http://localhost:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Invalid URL",
+			url:      "not-a-url",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTailscaleHostname(tt.url)
+			if result != tt.expected {
+				t.Errorf("IsTailscaleHostname(%s) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsTailscaleURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "Tailscale CGNAT IP",
+			url:      "http://100.64.0.1:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Tailscale MagicDNS",
+			url:      "http://my-device.ts.net:8200/events?stream=live-data",
+			expected: true,
+		},
+		{
+			name:     "Regular IP",
+			url:      "http://192.168.1.100:8200/events?stream=live-data",
+			expected: false,
+		},
+		{
+			name:     "Regular hostname",
+			url:      "http://example.com:8200/events?stream=live-data",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTailscaleURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("IsTailscaleURL(%s) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #116

This PR implements automatic Tailscale detection for all agents, not just auto-discovered ones.

## Changes
- Add utility functions to detect Tailscale CGNAT IPs (100.64.0.0/10) and IPv6 (fd7a:115c:a1e0::/48)
- Add support for Tailscale MagicDNS hostname detection (.ts.net, .beta.tailscale.net, .alpha.tailscale.net)
- Update CreateAgent handler to automatically set IsTailscale flag for manually added agents
- Update UpdateAgent handler to re-detect Tailscale status when URL changes (except for auto-discovered agents)
- Add comprehensive tests for new utility functions

## Testing
The implementation includes unit tests covering various IP ranges and hostname patterns.