### PR TITLE
feat(speedtest): add public LibreSpeed server support

### DIFF
--- a/internal/speedtest/librespeed.go
+++ b/internal/speedtest/librespeed.go
@@ -7,15 +7,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/netronome/internal/config"
 	"github.com/autobrr/netronome/internal/types"
+)
+
+const (
+	librespeedPublicServersURL = "https://librespeed.org/backend-servers/servers.json"
+	publicServerCacheDuration  = 30 * time.Minute
 )
 
 type LibrespeedResult struct {
@@ -59,9 +68,27 @@ type LibrespeedServer struct {
 	GetIpURL string `json:"getIpURL"`
 }
 
+// LibrespeedPublicServer represents a server from librespeed.org public list
+type LibrespeedPublicServer struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Server      string `json:"server"`
+	DlURL       string `json:"dlURL"`
+	UlURL       string `json:"ulURL"`
+	PingURL     string `json:"pingURL"`
+	GetIpURL    string `json:"getIpURL"`
+	SponsorName string `json:"sponsorName"`
+	SponsorURL  string `json:"sponsorURL"`
+}
+
 type LibrespeedRunner struct {
 	config           config.LibrespeedConfig
 	progressCallback func(types.SpeedUpdate)
+
+	// Public server cache
+	publicServerCache []LibrespeedPublicServer
+	cacheExpiry       time.Time
+	cacheMu           sync.RWMutex
 }
 
 func NewLibrespeedRunner(cfg config.LibrespeedConfig) *LibrespeedRunner {
@@ -79,18 +106,27 @@ func (r *LibrespeedRunner) SetProgressCallback(callback func(types.SpeedUpdate))
 }
 
 func (r *LibrespeedRunner) RunTest(ctx context.Context, opts *types.TestOptions) (*Result, error) {
-	log.Debug().Msg("starting librespeed test")
+	log.Debug().Bool("isPublicServer", opts.IsPublicServer).Msg("starting librespeed test")
 
-	args := []string{"--json", "--local-json", r.config.ServersPath}
+	// Check if librespeed-cli is installed first
+	if _, err := exec.LookPath("librespeed-cli"); err != nil {
+		return nil, fmt.Errorf("librespeed-cli not found: please install librespeed-cli to use this feature")
+	}
 
+	args := []string{"--json"}
+
+	// Custom servers require --local-json to specify the servers file
+	// Public servers use the built-in librespeed-cli server list
+	if !opts.IsPublicServer {
+		args = append(args, "--local-json", r.config.ServersPath)
+	}
+
+	// Add server selection if specified
 	if len(opts.ServerIDs) > 0 {
 		args = append(args, "--server", opts.ServerIDs[0])
 	}
 
-	// Check if librespeed-cli is installed
-	if _, err := exec.LookPath("librespeed-cli"); err != nil {
-		return nil, fmt.Errorf("librespeed-cli not found: please install librespeed-cli to use this feature")
-	}
+	log.Debug().Strs("args", args).Msg("librespeed-cli arguments")
 
 	cmd := exec.CommandContext(ctx, "librespeed-cli", args...)
 
@@ -142,15 +178,64 @@ func (r *LibrespeedRunner) RunTest(ctx context.Context, opts *types.TestOptions)
 }
 
 func (r *LibrespeedRunner) GetServers() ([]ServerResponse, error) {
+	var allServers []ServerResponse
+	var customErr, publicErr error
+
+	// 1. Load custom servers from local JSON
+	customServers, customErr := r.getCustomServers()
+	if customErr != nil {
+		log.Warn().Err(customErr).Msg("failed to load custom librespeed servers")
+	} else {
+		allServers = append(allServers, customServers...)
+	}
+
+	// 2. Fetch public servers from librespeed.org
+	publicServers, publicErr := r.fetchPublicServers()
+	if publicErr != nil {
+		log.Warn().Err(publicErr).Msg("failed to fetch public librespeed servers")
+	} else {
+		for _, server := range publicServers {
+			// Validate server data from external source
+			if server.ID <= 0 || server.Name == "" {
+				log.Debug().Int("id", server.ID).Str("name", server.Name).Msg("skipping invalid public server")
+				continue
+			}
+
+			country := parseCountryFromName(server.Name)
+			sponsor := server.SponsorName
+			if sponsor == "" {
+				sponsor = server.Name
+			}
+
+			allServers = append(allServers, ServerResponse{
+				ID:           strconv.Itoa(server.ID),
+				Name:         server.Name,
+				Host:         server.Server,
+				Country:      country,
+				Sponsor:      sponsor,
+				IsLibrespeed: true,
+				IsPublic:     true,
+			})
+		}
+	}
+
+	// Return error if both sources failed and we have no servers
+	if len(allServers) == 0 && (customErr != nil || publicErr != nil) {
+		return nil, fmt.Errorf("failed to load librespeed servers: custom=%v, public=%v", customErr, publicErr)
+	}
+
+	return allServers, nil
+}
+
+// getCustomServers loads servers from the local librespeed-servers.json file
+func (r *LibrespeedRunner) getCustomServers() ([]ServerResponse, error) {
 	jsonFile, err := os.Open(r.config.ServersPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Warn().Str("path", r.config.ServersPath).Msg("librespeed-servers.json not found")
-			// Return empty array instead of error when file doesn't exist
+			log.Debug().Str("path", r.config.ServersPath).Msg("librespeed-servers.json not found, skipping custom servers")
 			return []ServerResponse{}, nil
-		} else {
-			return nil, fmt.Errorf("failed to open librespeed-servers.json at %s: %w", r.config.ServersPath, err)
 		}
+		return nil, fmt.Errorf("failed to open librespeed-servers.json at %s: %w", r.config.ServersPath, err)
 	}
 	defer jsonFile.Close()
 
@@ -168,8 +253,67 @@ func (r *LibrespeedRunner) GetServers() ([]ServerResponse, error) {
 			Country:      "Custom",
 			Sponsor:      server.Name,
 			IsLibrespeed: true,
+			IsPublic:     false,
 		}
 	}
 
 	return response, nil
+}
+
+// fetchPublicServers fetches servers from librespeed.org with caching
+func (r *LibrespeedRunner) fetchPublicServers() ([]LibrespeedPublicServer, error) {
+	// Check cache first (with read lock)
+	r.cacheMu.RLock()
+	if len(r.publicServerCache) > 0 && time.Now().Before(r.cacheExpiry) {
+		servers := r.publicServerCache
+		r.cacheMu.RUnlock()
+		log.Debug().Int("count", len(servers)).Msg("returning cached public librespeed servers")
+		return servers, nil
+	}
+	r.cacheMu.RUnlock()
+
+	// Fetch from librespeed.org
+	log.Debug().Str("url", librespeedPublicServersURL).Msg("fetching public librespeed servers")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(librespeedPublicServersURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch public servers: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch public servers: status %d", resp.StatusCode)
+	}
+
+	// Limit response size to 10MB to prevent memory exhaustion from malicious responses
+	limitedReader := io.LimitReader(resp.Body, 10*1024*1024)
+
+	var servers []LibrespeedPublicServer
+	if err := json.NewDecoder(limitedReader).Decode(&servers); err != nil {
+		return nil, fmt.Errorf("failed to decode public servers: %w", err)
+	}
+
+	// Update cache (with write lock)
+	r.cacheMu.Lock()
+	r.publicServerCache = servers
+	r.cacheExpiry = time.Now().Add(publicServerCacheDuration)
+	r.cacheMu.Unlock()
+
+	log.Info().Int("count", len(servers)).Msg("fetched public librespeed servers")
+	return servers, nil
+}
+
+// parseCountryFromName extracts country from server names like "Amsterdam, Netherlands (Clouvider)"
+func parseCountryFromName(name string) string {
+	parts := strings.Split(name, ",")
+	if len(parts) >= 2 {
+		// Get the second part and strip any parenthetical info
+		countryPart := strings.TrimSpace(parts[1])
+		if idx := strings.Index(countryPart, "("); idx > 0 {
+			countryPart = strings.TrimSpace(countryPart[:idx])
+		}
+		return countryPart
+	}
+	return "Unknown"
 }

--- a/internal/speedtest/types.go
+++ b/internal/speedtest/types.go
@@ -35,6 +35,7 @@ type ServerResponse struct {
 	Lon          float64 `json:"lon,string"`
 	IsIperf      bool    `json:"isIperf"`
 	IsLibrespeed bool    `json:"isLibrespeed"`
+	IsPublic     bool    `json:"isPublic"`
 }
 
 type ProgressUpdate struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -19,6 +19,7 @@ type TestOptions struct {
 	UseLibrespeed    bool     `json:"useLibrespeed"`
 	ServerHost       string   `json:"serverHost"`
 	ServerName       string   `json:"serverName"`
+	IsPublicServer   bool     `json:"isPublicServer"`
 }
 
 type SpeedUpdate struct {

--- a/web/src/components/Main.tsx
+++ b/web/src/components/Main.tsx
@@ -122,11 +122,11 @@ export default function Main({ isPublic = false }: MainProps) {
     enabled: !isPublic,
   }) as { data: Server[] };
 
-  const { data: librespeedServers = [] } = useQuery({
+  const { data: librespeedServers = [], isLoading: isLibrespeedLoading, isError: isLibrespeedError } = useQuery({
     queryKey: ["servers", "librespeed"],
     queryFn: () => getServers("librespeed"),
     enabled: !isPublic,
-  }) as { data: Server[] };
+  }) as { data: Server[]; isLoading: boolean; isError: boolean };
 
   const allServers = useMemo(
     () => [...speedtestServers, ...librespeedServers],
@@ -309,6 +309,7 @@ export default function Main({ isPublic = false }: MainProps) {
             : [],
         serverHost: testType === "iperf" ? selectedServers[0].host : undefined,
         serverName: testType === "iperf" ? selectedServers[0].name : undefined,
+        isPublicServer: testType === "librespeed" ? (selectedServers[0]?.isPublic ?? false) : false,
       });
     } catch (error) {
       console.error("Error running test:", error);
@@ -560,6 +561,8 @@ export default function Main({ isPublic = false }: MainProps) {
                 onRunTest={runTest}
                 progress={progress}
                 allServers={allServers}
+                isServersLoading={testType === "librespeed" ? isLibrespeedLoading : false}
+                isServersError={testType === "librespeed" ? isLibrespeedError : false}
               />
             </motion.div>
           )}

--- a/web/src/components/speedtest/ScheduleManager.tsx
+++ b/web/src/components/speedtest/ScheduleManager.tsx
@@ -319,6 +319,7 @@ export default function ScheduleManager({
         useLibrespeed: isLibrespeedServer,
         serverHost: isIperfServer ? selectedServers[0].host : undefined,
         serverName: isIperfServer ? selectedServers[0].name : undefined,
+        isPublicServer: isLibrespeedServer ? (selectedServers[0]?.isPublic ?? false) : false,
       },
     };
 

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -46,6 +46,8 @@ interface ServerListProps {
   isLoading: boolean;
   testType: "speedtest" | "iperf" | "librespeed";
   onTestTypeChange: (testType: "speedtest" | "iperf" | "librespeed") => void;
+  isServersLoading?: boolean;
+  isServersError?: boolean;
 }
 
 export const ServerList: React.FC<ServerListProps> = ({
@@ -58,6 +60,8 @@ export const ServerList: React.FC<ServerListProps> = ({
   isLoading,
   testType,
   onTestTypeChange,
+  isServersLoading,
+  isServersError,
 }) => {
   const getInitialDisplayCount = () => {
     if (typeof window !== "undefined") {
@@ -522,33 +526,34 @@ export const ServerList: React.FC<ServerListProps> = ({
                       testType === "librespeed" ? (
                         <div className="flex flex-col items-center justify-center py-12 px-4">
                           <div className="text-center max-w-md">
-                            <div className="text-gray-600 dark:text-gray-400 text-lg mb-2">📡</div>
-                            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-300 mb-2">
-                              No Librespeed servers found
-                            </h3>
-                            <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
-                              The librespeed-servers.json file was not found.
-                              Please create this file in the same directory as
-                              your config.toml to run librespeed tests.
-                            </p>
-                            <div className="text-xs text-gray-600 dark:text-gray-500 bg-gray-100/30 dark:bg-gray-800/30 rounded-lg p-3 border border-gray-300 dark:border-gray-900">
-                              <p className="mb-2">
-                                Example librespeed-servers.json:
-                              </p>
-                              <pre className="text-left">
-                                {`[
-  {
-    "id": 1,
-    "name": "Example Server",
-    "server": "https://example.com/backend",
-    "dlURL": "garbage.php",
-    "ulURL": "empty.php",
-    "pingURL": "empty.php",
-    "getIpURL": "getIP.php"
-  }
-]`}
-                              </pre>
-                            </div>
+                            {isServersLoading ? (
+                              <>
+                                <h3 className="text-lg font-medium text-gray-900 dark:text-gray-300 mb-2">
+                                  Loading LibreSpeed servers...
+                                </h3>
+                                <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
+                                  Fetching public servers from LibreSpeed.org.
+                                </p>
+                              </>
+                            ) : isServersError ? (
+                              <>
+                                <h3 className="text-lg font-medium text-red-600 dark:text-red-400 mb-2">
+                                  Failed to load servers
+                                </h3>
+                                <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
+                                  Could not fetch LibreSpeed servers. Check your network connection or add custom servers via librespeed-servers.json.
+                                </p>
+                              </>
+                            ) : (
+                              <>
+                                <h3 className="text-lg font-medium text-gray-900 dark:text-gray-300 mb-2">
+                                  No LibreSpeed servers found
+                                </h3>
+                                <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
+                                  No servers matched your search. Try adjusting your filters or add custom servers via librespeed-servers.json.
+                                </p>
+                              </>
+                            )}
                           </div>
                         </div>
                       ) : (
@@ -575,9 +580,22 @@ export const ServerList: React.FC<ServerListProps> = ({
                                     } border`}
                                   >
                                     <div className="flex flex-col gap-1">
-                                      <span className="text-blue-600 dark:text-blue-300 font-medium truncate">
-                                        {server.sponsor}
-                                      </span>
+                                      <div className="flex items-center gap-2">
+                                        <span className="text-blue-600 dark:text-blue-300 font-medium truncate">
+                                          {server.sponsor}
+                                        </span>
+                                        {server.isLibrespeed && (
+                                          <span
+                                            className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                                              server.isPublic
+                                                ? "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+                                                : "bg-purple-500/10 text-purple-600 dark:text-purple-400"
+                                            }`}
+                                          >
+                                            {server.isPublic ? "Public" : "Custom"}
+                                          </span>
+                                        )}
+                                      </div>
                                       <span className="text-gray-600 dark:text-gray-400 text-sm">
                                         {server.name}
                                         <span

--- a/web/src/components/speedtest/SpeedTestTab.tsx
+++ b/web/src/components/speedtest/SpeedTestTab.tsx
@@ -21,6 +21,8 @@ interface SpeedTestTabProps {
   onRunTest: () => Promise<void>;
   progress: TestProgressType | null;
   allServers: Server[];
+  isServersLoading?: boolean;
+  isServersError?: boolean;
 }
 
 export const SpeedTestTab: React.FC<SpeedTestTabProps> = ({
@@ -32,6 +34,8 @@ export const SpeedTestTab: React.FC<SpeedTestTabProps> = ({
   isLoading,
   onRunTest,
   allServers,
+  isServersLoading,
+  isServersError,
 }) => {
   return (
     <div className="flex flex-col md:flex-row gap-6 md:items-start">
@@ -53,6 +57,8 @@ export const SpeedTestTab: React.FC<SpeedTestTabProps> = ({
           isLoading={isLoading}
           testType={testType}
           onTestTypeChange={onTestTypeChange}
+          isServersLoading={isServersLoading}
+          isServersError={isServersError}
         />
       </motion.div>
 

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -15,6 +15,7 @@ export interface Server {
   longitude: number;
   isIperf: boolean;
   isLibrespeed?: boolean;
+  isPublic?: boolean;
 }
 
 export interface SpeedTestResult {
@@ -58,6 +59,7 @@ export interface Schedule {
     useLibrespeed?: boolean;
     serverHost: string | undefined;
     serverName?: string | undefined;
+    isPublicServer?: boolean;
   };
 }
 
@@ -71,6 +73,7 @@ export interface TestOptions {
   serverIds?: string[];
   serverHost?: string;
   serverName?: string;
+  isPublicServer?: boolean;
 }
 
 export type TimeRange = "1d" | "3d" | "1w" | "1m" | "all";


### PR DESCRIPTION
- Fetch and cache public servers from librespeed.org (30min TTL)
- Display both public and custom servers in server list
- Add Public/Custom badges to distinguish server sources
- Use correct CLI args based on server type (public vs custom)
- Support isPublicServer in test options and schedules

Closes #144