### PR TITLE
Handle string-to-time conversion for monitor agent timestamp fields

### DIFF
--- a/internal/database/monitor.go
+++ b/internal/database/monitor.go
@@ -56,6 +56,8 @@ func (s *service) GetMonitorAgent(ctx context.Context, agentID int64) (*types.Mo
 		Where(sq.Eq{"id": agentID})
 
 	var agent types.MonitorAgent
+	var discoveredAtStr sql.NullString
+	var createdAtStr, updatedAtStr string
 	err := query.RunWith(s.db).QueryRowContext(ctx).Scan(
 		&agent.ID,
 		&agent.Name,
@@ -65,15 +67,28 @@ func (s *service) GetMonitorAgent(ctx context.Context, agentID int64) (*types.Mo
 		&agent.Interface,
 		&agent.IsTailscale,
 		&agent.TailscaleHostname,
-		&agent.DiscoveredAt,
-		&agent.CreatedAt,
-		&agent.UpdatedAt,
+		&discoveredAtStr,
+		&createdAtStr,
+		&updatedAtStr,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to get monitor agent: %w", err)
+	}
+
+	// Parse time strings
+	if discoveredAtStr.Valid {
+		if t, err := time.Parse(time.RFC3339, discoveredAtStr.String); err == nil {
+			agent.DiscoveredAt = &t
+		}
+	}
+	if t, err := time.Parse(time.RFC3339, createdAtStr); err == nil {
+		agent.CreatedAt = t
+	}
+	if t, err := time.Parse(time.RFC3339, updatedAtStr); err == nil {
+		agent.UpdatedAt = t
 	}
 
 	return &agent, nil
@@ -99,6 +114,8 @@ func (s *service) GetMonitorAgents(ctx context.Context, enabledOnly bool) ([]*ty
 	agents := make([]*types.MonitorAgent, 0)
 	for rows.Next() {
 		var agent types.MonitorAgent
+		var discoveredAtStr sql.NullString
+		var createdAtStr, updatedAtStr string
 		err := rows.Scan(
 			&agent.ID,
 			&agent.Name,
@@ -108,13 +125,27 @@ func (s *service) GetMonitorAgents(ctx context.Context, enabledOnly bool) ([]*ty
 			&agent.Interface,
 			&agent.IsTailscale,
 			&agent.TailscaleHostname,
-			&agent.DiscoveredAt,
-			&agent.CreatedAt,
-			&agent.UpdatedAt,
+			&discoveredAtStr,
+			&createdAtStr,
+			&updatedAtStr,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan monitor agent: %w", err)
 		}
+
+		// Parse time strings
+		if discoveredAtStr.Valid {
+			if t, err := time.Parse(time.RFC3339, discoveredAtStr.String); err == nil {
+				agent.DiscoveredAt = &t
+			}
+		}
+		if t, err := time.Parse(time.RFC3339, createdAtStr); err == nil {
+			agent.CreatedAt = t
+		}
+		if t, err := time.Parse(time.RFC3339, updatedAtStr); err == nil {
+			agent.UpdatedAt = t
+		}
+
 		agents = append(agents, &agent)
 	}
 


### PR DESCRIPTION
## Summary

Fix database scanning for `MonitorAgent` timestamp fields where the database stores values as strings but the Go struct expects `time.Time` types.

## Problem

The `monitor_agents` table stores `discovered_at`, `created_at`, and `updated_at` columns as string values, but the `MonitorAgent` struct in Go uses `time.Time` and `*time.Time` types for these fields. This caused type mismatch errors when scanning rows from the database.

<img width="2879" height="251" alt="image" src="https://github.com/user-attachments/assets/426b8781-90d7-45cd-b4d2-fd791f108f8c" />

## Solution

Updated `GetMonitorAgent` and `GetMonitorAgents` functions in `internal/database/monitor.go` to:

1. Scan timestamp columns into intermediate string variables:
   - `sql.NullString` for the nullable `discovered_at` field
   - Regular `string` for non-nullable `created_at` and `updated_at` fields

2. Parse the string values into `time.Time` using `time.Parse(time.RFC3339, ...)` after scanning

## Changes

- **`GetMonitorAgent`**: Added string-to-time parsing for single agent retrieval
- **`GetMonitorAgents`**: Added string-to-time parsing for batch agent retrieval