### PR TITLE
fix(web): remove extra colon in Pushover notification example

### DIFF
--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -208,7 +208,7 @@ export const SHOUTRRR_SERVICES = [
   { value: "ntfy", label: "ntfy", example: "ntfy://[USER:PASS@]HOSTNAME/topic" },
   { value: "opsgenie", label: "OpsGenie", example: "opsgenie://APIKEY" },
   { value: "pushbullet", label: "Pushbullet", example: "pushbullet://APIKEY" },
-  { value: "pushover", label: "Pushover", example: "pushover://:API_TOKEN@USER_KEY" },
+  { value: "pushover", label: "Pushover", example: "pushover://API_TOKEN@USER_KEY" },
   { value: "rocketchat", label: "Rocket.Chat", example: "rocketchat://HOSTNAME/TOKEN@CHANNEL" },
   { value: "slack", label: "Slack", example: "slack://TOKEN@CHANNEL" },
   { value: "teams", label: "Microsoft Teams", example: "teams://WEBHOOK_URL" },


### PR DESCRIPTION
## Summary
- Removes the extra colon in the Pushover URL example (`pushover://:API_TOKEN@USER_KEY` -> `pushover://API_TOKEN@USER_KEY`)

Fixes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example URL format for Pushover notification service configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->