### PR TITLE
feat(web): add generic webhook as notification service option

### DIFF
--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -198,6 +198,7 @@ export const notificationsApi = {
 // Helper functions
 export const SHOUTRRR_SERVICES = [
   { value: "discord", label: "Discord", example: "discord://TOKEN@ID" },
+  { value: "generic", label: "Generic Webhook", example: "generic://HOSTNAME/PATH?template=json" },
   { value: "gotify", label: "Gotify", example: "gotify://HOSTNAME/TOKEN" },
   { value: "email", label: "Email", example: "smtp://USERNAME:PASSWORD@HOST:PORT/?from=FROM&to=TO" },
   { value: "googlechat", label: "Google Chat", example: "googlechat://SPACE/KEY/TOKEN" },
@@ -208,7 +209,7 @@ export const SHOUTRRR_SERVICES = [
   { value: "ntfy", label: "ntfy", example: "ntfy://[USER:PASS@]HOSTNAME/topic" },
   { value: "opsgenie", label: "OpsGenie", example: "opsgenie://APIKEY" },
   { value: "pushbullet", label: "Pushbullet", example: "pushbullet://APIKEY" },
-  { value: "pushover", label: "Pushover", example: "pushover://:API_TOKEN@USER_KEY" },
+  { value: "pushover", label: "Pushover", example: "pushover://API_TOKEN@USER_KEY" },
   { value: "rocketchat", label: "Rocket.Chat", example: "rocketchat://HOSTNAME/TOKEN@CHANNEL" },
   { value: "slack", label: "Slack", example: "slack://TOKEN@CHANNEL" },
   { value: "teams", label: "Microsoft Teams", example: "teams://WEBHOOK_URL" },


### PR DESCRIPTION
## Summary
- Adds "Generic Webhook" as a selectable notification service type in the notification settings UI
- Uses the Shoutrrr `generic://` URL scheme which was already supported by the backend but missing from the frontend dropdown

Closes #125

## Test plan
- [ ] Navigate to Settings > Notifications
- [ ] Create a new notification channel
- [ ] Verify "Generic Webhook" appears in the service type dropdown
- [ ] Verify the example URL shows `generic://HOSTNAME/PATH?template=json`
- [ ] Test sending a notification to a generic webhook endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Generic Webhook as a new notification service option.

* **Bug Fixes**
  * Corrected the Pushover service configuration example format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->