### PR TITLE
feat(packetloss): add option to enable DNS resolution in MTR tests

### DIFF
--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -238,7 +238,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	// create packet loss service if enabled
 	if cfg.PacketLoss.Enabled {
 		// We'll set the actual broadcaster after creating the server
-		packetLossService = speedtest.NewPacketLossService(db, notifier, nil, cfg.PacketLoss.MaxConcurrentMonitors, cfg.PacketLoss.PrivilegedMode)
+		packetLossService = speedtest.NewPacketLossService(db, notifier, nil, cfg.PacketLoss.MaxConcurrentMonitors, cfg.PacketLoss.PrivilegedMode, cfg.PacketLoss.MTREnableDNS)
 	}
 
 	// Create monitor service variable

--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,7 @@ default_interval = 3600
 default_packet_count = 10
 max_concurrent_monitors = 10
 privileged_mode = true
+mtr_enable_dns = false
 
 [monitor]
 enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ type PacketLossConfig struct {
 	DefaultPacketCount       int  `toml:"default_packet_count" env:"PACKETLOSS_DEFAULT_PACKET_COUNT"`
 	MaxConcurrentMonitors    int  `toml:"max_concurrent_monitors" env:"PACKETLOSS_MAX_CONCURRENT_MONITORS"`
 	PrivilegedMode           bool `toml:"privileged_mode" env:"PACKETLOSS_PRIVILEGED_MODE"`
+	MTREnableDNS             bool `toml:"mtr_enable_dns" env:"PACKETLOSS_MTR_ENABLE_DNS"`
 	RestoreMonitorsOnStartup bool `toml:"restore_monitors_on_startup" env:"PACKETLOSS_RESTORE_MONITORS_ON_STARTUP"`
 }
 
@@ -276,6 +277,7 @@ func New() *Config {
 			DefaultPacketCount:       10,
 			MaxConcurrentMonitors:    10,
 			PrivilegedMode:           true,
+			MTREnableDNS:             false,
 			RestoreMonitorsOnStartup: false,
 		},
 		Agent: AgentConfig{
@@ -586,6 +588,11 @@ func (c *Config) loadPacketLossFromEnv() {
 			c.PacketLoss.PrivilegedMode = privileged
 		}
 	}
+	if v := getEnv("PACKETLOSS_MTR_ENABLE_DNS"); v != "" {
+		if enableDNS, err := strconv.ParseBool(v); err == nil {
+			c.PacketLoss.MTREnableDNS = enableDNS
+		}
+	}
 	if v := getEnv("PACKETLOSS_RESTORE_MONITORS_ON_STARTUP"); v != "" {
 		if restore, err := strconv.ParseBool(v); err == nil {
 			c.PacketLoss.RestoreMonitorsOnStartup = restore
@@ -861,6 +868,9 @@ func (c *Config) WriteToml(w io.Writer) error {
 		return err
 	}
 	if _, err := fmt.Fprintf(w, "privileged_mode = %v # Use privileged ICMP mode for better MTR support (requires root/sudo)\n", cfg.PacketLoss.PrivilegedMode); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "mtr_enable_dns = %v # Enable DNS resolution in MTR tests to show hostnames instead of IPs\n", cfg.PacketLoss.MTREnableDNS); err != nil {
 		return err
 	}
 

--- a/internal/speedtest/mtr_unix.go
+++ b/internal/speedtest/mtr_unix.go
@@ -44,21 +44,25 @@ func killMTRProcessGroup(pid int) error {
 
 // buildMTRArgs builds Unix-specific MTR arguments
 // On Unix, we can use the -j flag for JSON output directly
-func buildMTRArgs(host string, packetCount int, privilegedMode bool) ([]string, string, error) {
+func buildMTRArgs(host string, packetCount int, privilegedMode bool, enableDNS bool) ([]string, string, error) {
 	args := []string{
-		"-4",                                         // Force IPv4
-		"-j",                                         // JSON output
-		"-c", fmt.Sprintf("%d", packetCount),         // Number of cycles
-		"-i", "1",                                    // 1 second interval
-		"--no-dns",                                   // Skip DNS resolution for speed
-		host,
+		"-4",                                 // Force IPv4
+		"-j",                                 // JSON output
+		"-c", fmt.Sprintf("%d", packetCount), // Number of cycles
+		"-i", "1",                            // 1 second interval
 	}
-	
+
+	if !enableDNS {
+		args = append(args, "--no-dns")
+	}
+
+	args = append(args, host)
+
 	// Add UDP mode if not privileged
 	if !privilegedMode {
 		args = append([]string{"-u"}, args...)
 	}
-	
+
 	// Return empty string to indicate Unix doesn't need parsing
 	return args, "", nil
 }

--- a/internal/speedtest/mtr_windows.go
+++ b/internal/speedtest/mtr_windows.go
@@ -67,16 +67,22 @@ func killMTRProcessGroup(pid int) error {
 // buildMTRArgs builds Windows-specific MTR arguments
 // Windows MTR doesn't support -j for JSON output, so we use -r for report mode
 // and -w for wide format, then capture stdout and parse it
-func buildMTRArgs(host string, packetCount int, privilegedMode bool) ([]string, string, error) {
+func buildMTRArgs(host string, packetCount int, privilegedMode bool, enableDNS bool) ([]string, string, error) {
 	args := []string{
 		"-4",                                 // Force IPv4
 		"-r",                                 // Report mode
 		"-w",                                 // Wide report, don't truncate hostnames
-		"-n",                                 // No DNS lookups (numeric output only)
+	}
+
+	if !enableDNS {
+		args = append(args, "-n") // No DNS lookups (numeric output only)
+	}
+
+	args = append(args,
 		"-c", fmt.Sprintf("%d", packetCount), // Number of cycles
 		"-i", "1", // 1 second interval
 		"-t", "2", // 2 second timeout per hop to prevent hanging on unresponsive hops
-	}
+	)
 
 	// Add UDP mode if not privileged (Windows MTR defaults to ICMP in privileged mode)
 	if !privilegedMode {

--- a/internal/speedtest/packetloss.go
+++ b/internal/speedtest/packetloss.go
@@ -51,10 +51,11 @@ type PacketLossService struct {
 	}
 	maxConcurrent  int
 	privilegedMode bool
+	enableDNS      bool
 }
 
 // NewPacketLossService creates a new packet loss monitoring service
-func NewPacketLossService(db database.Service, notifier *notifications.Notifier, broadcast func(types.PacketLossUpdate), maxConcurrent int, privilegedMode bool) *PacketLossService {
+func NewPacketLossService(db database.Service, notifier *notifications.Notifier, broadcast func(types.PacketLossUpdate), maxConcurrent int, privilegedMode bool, enableDNS bool) *PacketLossService {
 	if maxConcurrent <= 0 {
 		maxConcurrent = 10
 	}
@@ -69,6 +70,7 @@ func NewPacketLossService(db database.Service, notifier *notifications.Notifier,
 		broadcast:      broadcast,
 		maxConcurrent:  maxConcurrent,
 		privilegedMode: privilegedMode,
+		enableDNS:      enableDNS,
 	}
 }
 
@@ -1007,7 +1009,7 @@ func (s *PacketLossService) runMTRTest(monitor *PacketLossMonitor) (*probing.Sta
 	defer cancel()
 
 	// Build platform-specific MTR command arguments
-	args, platformFlag, err := buildMTRArgs(monitor.Host, monitor.PacketCount, s.privilegedMode)
+	args, platformFlag, err := buildMTRArgs(monitor.Host, monitor.PacketCount, s.privilegedMode, s.enableDNS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build MTR arguments: %w", err)
 	}
@@ -1174,7 +1176,7 @@ func (s *PacketLossService) runMTRTest(monitor *PacketLossMonitor) (*probing.Sta
 				Msg("MTR privileged mode failed, trying UDP mode")
 
 			// Rebuild args with UDP mode for retry
-			retryArgs, retryPlatformFlag, buildErr := buildMTRArgs(monitor.Host, monitor.PacketCount, false)
+			retryArgs, retryPlatformFlag, buildErr := buildMTRArgs(monitor.Host, monitor.PacketCount, false, s.enableDNS)
 			if buildErr != nil {
 				return nil, fmt.Errorf("failed to build retry MTR arguments: %w", buildErr)
 			}


### PR DESCRIPTION
## Summary

- Adds `mtr_enable_dns` config option to the `[packetloss]` section that controls whether MTR tests resolve hostnames or show raw IP addresses
- Disabled by default to preserve current behavior (fast, numeric-only output)
- When enabled, removes `--no-dns` (Unix) / `-n` (Windows) flags from MTR commands so hostnames like `one.one.one.one` are shown instead of `1.1.1.1`
- Configurable via config file (`mtr_enable_dns = true`) or environment variable (`NETRONOME__PACKETLOSS_MTR_ENABLE_DNS=true`)

Closes #160

## Test plan

- [x] `go build ./...` compiles without errors
- [x] `go test ./...` all tests pass
- [ ] Start with `mtr_enable_dns = false` (default) and verify MTR results show IP addresses only
- [ ] Start with `mtr_enable_dns = true` and verify MTR results show resolved hostnames
- [ ] Set `NETRONOME__PACKETLOSS_MTR_ENABLE_DNS=true` env var and verify it overrides the config file
- [ ] Run `generate-config` and verify the new option appears in the generated config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control DNS lookup behavior during packet loss monitoring tests, allowing users to toggle DNS resolution checks during network diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->