### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/cmd/netronome/update.go
+++ b/cmd/netronome/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/cmd/netronome/version.go
+++ b/cmd/netronome/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/bandwidth.go
+++ b/internal/agent/bandwidth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/broadcast.go
+++ b/internal/agent/broadcast.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/disk_utils.go
+++ b/internal/agent/disk_utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/hardware.go
+++ b/internal/agent/hardware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/middleware.go
+++ b/internal/agent/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/routes.go
+++ b/internal/agent/routes.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/smart.go
+++ b/internal/agent/smart.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build !nosmart && (linux || darwin)

--- a/internal/agent/smart_stub.go
+++ b/internal/agent/smart_stub.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build nosmart || (!linux && !darwin)

--- a/internal/agent/system.go
+++ b/internal/agent/system.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/tailscale.go
+++ b/internal/agent/tailscale.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package agent

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package auth

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package auth

--- a/internal/broadcaster/broadcaster.go
+++ b/internal/broadcaster/broadcaster.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package broadcaster

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/config/tailscale_config_test.go
+++ b/internal/config/tailscale_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/database/cascade_delete_integration_test.go
+++ b/internal/database/cascade_delete_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/core_integration_test.go
+++ b/internal/database/core_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 // Package database contains database tests and test helpers.

--- a/internal/database/iperf.go
+++ b/internal/database/iperf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/iperf_integration_test.go
+++ b/internal/database/iperf_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/migrations/migrations.go
+++ b/internal/database/migrations/migrations.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package migrations

--- a/internal/database/migrations_integration_test.go
+++ b/internal/database/migrations_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/migrations_postgres_test.go
+++ b/internal/database/migrations_postgres_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/monitor.go
+++ b/internal/database/monitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/monitor_data.go
+++ b/internal/database/monitor_data.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/monitor_integration_test.go
+++ b/internal/database/monitor_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/notifications.go
+++ b/internal/database/notifications.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/notifications_integration_test.go
+++ b/internal/database/notifications_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/notifications_types.go
+++ b/internal/database/notifications_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/packetloss.go
+++ b/internal/database/packetloss.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/packetloss_integration_test.go
+++ b/internal/database/packetloss_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/packetloss_test.go
+++ b/internal/database/packetloss_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/schedule.go
+++ b/internal/database/schedule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/schedule_integration_test.go
+++ b/internal/database/schedule_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/speedtest.go
+++ b/internal/database/speedtest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/speedtest_integration_test.go
+++ b/internal/database/speedtest_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/handlers/iperf.go
+++ b/internal/handlers/iperf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package handlers

--- a/internal/handlers/monitor.go
+++ b/internal/handlers/monitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package handlers

--- a/internal/handlers/packetloss.go
+++ b/internal/handlers/packetloss.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package handlers

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/monitor/client.go
+++ b/internal/monitor/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package monitor

--- a/internal/monitor/tailscale_discovery.go
+++ b/internal/monitor/tailscale_discovery.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package monitor

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notifications

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package scheduler

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package scheduler
 
 import (

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/auth_oidc.go
+++ b/internal/server/auth_oidc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/notification_handlers.go
+++ b/internal/server/notification_handlers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/speedtest/iperf.go
+++ b/internal/speedtest/iperf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/librespeed.go
+++ b/internal/speedtest/librespeed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/mtr_unix.go
+++ b/internal/speedtest/mtr_unix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build !windows

--- a/internal/speedtest/mtr_windows.go
+++ b/internal/speedtest/mtr_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build windows

--- a/internal/speedtest/packetloss.go
+++ b/internal/speedtest/packetloss.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/packetloss_mtr_test.go
+++ b/internal/speedtest/packetloss_mtr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/ping.go
+++ b/internal/speedtest/ping.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/progress_broadcaster.go
+++ b/internal/speedtest/progress_broadcaster.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/result_handler.go
+++ b/internal/speedtest/result_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/speedtest.go
+++ b/internal/speedtest/speedtest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/speedtest_net.go
+++ b/internal/speedtest/speedtest_net.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/traceroute.go
+++ b/internal/speedtest/traceroute.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/speedtest/types.go
+++ b/internal/speedtest/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package speedtest

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package tailscale

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package types

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package utils

--- a/internal/utils/tailscale.go
+++ b/internal/utils/tailscale.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package utils
 
 import (

--- a/internal/utils/tailscale_test.go
+++ b/internal/utils/tailscale_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package utils

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package version

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package migrator

--- a/web/build.go
+++ b/web/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025, s0up and the autobrr contributors.
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package web

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/monitor.ts
+++ b/web/src/api/monitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/packetloss.ts
+++ b/web/src/api/packetloss.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/speedtest.ts
+++ b/web/src/api/speedtest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/tailscale.ts
+++ b/web/src/api/tailscale.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/DarkModeToggle.tsx
+++ b/web/src/components/DarkModeToggle.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/DonateModal.tsx
+++ b/web/src/components/DonateModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/Main.tsx
+++ b/web/src/components/Main.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/PWAUpdatePrompt.tsx
+++ b/web/src/components/PWAUpdatePrompt.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/SettingsMenu.tsx
+++ b/web/src/components/SettingsMenu.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/auth/Register.tsx
+++ b/web/src/components/auth/Register.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/common/DeleteConfirmationDialog.tsx
+++ b/web/src/components/common/DeleteConfirmationDialog.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/common/MetricCard.tsx
+++ b/web/src/components/common/MetricCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/common/TabNavigation.tsx
+++ b/web/src/components/common/TabNavigation.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/common/Toast.tsx
+++ b/web/src/components/common/Toast.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/icons/TailscaleLogo.tsx
+++ b/web/src/components/icons/TailscaleLogo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/FeaturedMonitorWidget.tsx
+++ b/web/src/components/monitor/FeaturedMonitorWidget.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorAgentDetailsTabs.tsx
+++ b/web/src/components/monitor/MonitorAgentDetailsTabs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorAgentForm.tsx
+++ b/web/src/components/monitor/MonitorAgentForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorAgentList.tsx
+++ b/web/src/components/monitor/MonitorAgentList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorBandwidthChart.tsx
+++ b/web/src/components/monitor/MonitorBandwidthChart.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorDataPrefetcher.tsx
+++ b/web/src/components/monitor/MonitorDataPrefetcher.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorHardwareStats.tsx
+++ b/web/src/components/monitor/MonitorHardwareStats.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorOfflineBanner.tsx
+++ b/web/src/components/monitor/MonitorOfflineBanner.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorSystemInfo.tsx
+++ b/web/src/components/monitor/MonitorSystemInfo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorTab.tsx
+++ b/web/src/components/monitor/MonitorTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/MonitorUsageModal.tsx
+++ b/web/src/components/monitor/MonitorUsageModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/tabs/MonitorBandwidthTab.tsx
+++ b/web/src/components/monitor/tabs/MonitorBandwidthTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/tabs/MonitorOverviewTab.tsx
+++ b/web/src/components/monitor/tabs/MonitorOverviewTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/monitor/tabs/MonitorSystemTab.tsx
+++ b/web/src/components/monitor/tabs/MonitorSystemTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/NotificationSettings.tsx
+++ b/web/src/components/settings/NotificationSettings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/TimeFormatSettings.tsx
+++ b/web/src/components/settings/TimeFormatSettings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/AddChannelForm.tsx
+++ b/web/src/components/settings/notifications/AddChannelForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/ChannelCard.tsx
+++ b/web/src/components/settings/notifications/ChannelCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/ChannelDetails.tsx
+++ b/web/src/components/settings/notifications/ChannelDetails.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/EventCategorySection.tsx
+++ b/web/src/components/settings/notifications/EventCategorySection.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/EventRuleItem.tsx
+++ b/web/src/components/settings/notifications/EventRuleItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/MobileNotificationView.tsx
+++ b/web/src/components/settings/notifications/MobileNotificationView.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/settings/notifications/index.ts
+++ b/web/src/components/settings/notifications/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/DashboardTab.tsx
+++ b/web/src/components/speedtest/DashboardTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/IperfServerModal.tsx
+++ b/web/src/components/speedtest/IperfServerModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/ScheduleManager.tsx
+++ b/web/src/components/speedtest/ScheduleManager.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/ServerList.tsx
+++ b/web/src/components/speedtest/ServerList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/ShareModal.tsx
+++ b/web/src/components/speedtest/ShareModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/SpeedHistoryChart.tsx
+++ b/web/src/components/speedtest/SpeedHistoryChart.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/SpeedTestTab.tsx
+++ b/web/src/components/speedtest/SpeedTestTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/TestProgress.tsx
+++ b/web/src/components/speedtest/TestProgress.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/TracerouteTab.tsx
+++ b/web/src/components/speedtest/TracerouteTab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/columns.tsx
+++ b/web/src/components/speedtest/columns.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/DeleteMonitorModal.tsx
+++ b/web/src/components/speedtest/packetloss/DeleteMonitorModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorForm.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/CountryFlag.tsx
+++ b/web/src/components/speedtest/packetloss/components/CountryFlag.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/EmptyStatePlaceholder.tsx
+++ b/web/src/components/speedtest/packetloss/components/EmptyStatePlaceholder.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/MTRResultsDisplay.tsx
+++ b/web/src/components/speedtest/packetloss/components/MTRResultsDisplay.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorPerformanceChart.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/components/MonitorStatusCard.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorStatusCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/constants/packetLossConstants.ts
+++ b/web/src/components/speedtest/packetloss/constants/packetLossConstants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts
+++ b/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/types/monitorStatus.ts
+++ b/web/src/components/speedtest/packetloss/types/monitorStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/packetloss/utils/packetLossUtils.ts
+++ b/web/src/components/speedtest/packetloss/utils/packetLossUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/TracerouteLiveResults.tsx
+++ b/web/src/components/speedtest/traceroute/TracerouteLiveResults.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/TracerouteProgress.tsx
+++ b/web/src/components/speedtest/traceroute/TracerouteProgress.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/TracerouteResults.tsx
+++ b/web/src/components/speedtest/traceroute/TracerouteResults.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/TracerouteServerSelector.tsx
+++ b/web/src/components/speedtest/traceroute/TracerouteServerSelector.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/components/ServerCard.tsx
+++ b/web/src/components/speedtest/traceroute/components/ServerCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/components/ServerFilters.tsx
+++ b/web/src/components/speedtest/traceroute/components/ServerFilters.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/components/TracerouteMobileCards.tsx
+++ b/web/src/components/speedtest/traceroute/components/TracerouteMobileCards.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/components/TracerouteTable.tsx
+++ b/web/src/components/speedtest/traceroute/components/TracerouteTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/constants/tracerouteConstants.ts
+++ b/web/src/components/speedtest/traceroute/constants/tracerouteConstants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/hooks/useServerData.ts
+++ b/web/src/components/speedtest/traceroute/hooks/useServerData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/hooks/useTracerouteExecution.ts
+++ b/web/src/components/speedtest/traceroute/hooks/useTracerouteExecution.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/hooks/useTracerouteStatus.ts
+++ b/web/src/components/speedtest/traceroute/hooks/useTracerouteStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/utils/serverUtils.ts
+++ b/web/src/components/speedtest/traceroute/utils/serverUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/speedtest/traceroute/utils/tracerouteUtils.ts
+++ b/web/src/components/speedtest/traceroute/utils/tracerouteUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/collapsible.tsx
+++ b/web/src/components/ui/collapsible.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/data-table.tsx
+++ b/web/src/components/ui/data-table.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/constants/monitorRefreshIntervals.ts
+++ b/web/src/constants/monitorRefreshIntervals.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/hooks/useMonitorAgent.ts
+++ b/web/src/hooks/useMonitorAgent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/styles/tab-navigation.css
+++ b/web/src/styles/tab-navigation.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 /* Mobile bottom navigation styles using custom zinc-based gray colors */
 @media (max-width: 639px) {
   .tab-navigation-container {

--- a/web/src/types/speedtest.ts
+++ b/web/src/types/speedtest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/agentIcons.tsx
+++ b/web/src/utils/agentIcons.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/baseUrl.ts
+++ b/web/src/utils/baseUrl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/countryFlags.ts
+++ b/web/src/utils/countryFlags.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/darkMode.ts
+++ b/web/src/utils/darkMode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/formatBytes.ts
+++ b/web/src/utils/formatBytes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/monitorDataParser.ts
+++ b/web/src/utils/monitorDataParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/timeSettings.ts
+++ b/web/src/utils/timeSettings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/timeUtils.ts
+++ b/web/src/utils/timeUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 


### PR DESCRIPTION
## Summary
- Updated all license headers from `2024-2025` to `2024-2026` across 197 source files
- Updated `license.sh` to use `2024-2026` in header templates and handle `2024-2025` -> `2024-2026` transitions in the year update function
- 4 new files received headers for the first time

## Test plan
- [x] Ran `./license.sh false` successfully
- [ ] Verify no unintended file changes with `git diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year notices across the codebase and added license headers to select files. No functional or behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->