### PR TITLE
feat(agent): add flag to disable system metrics collection

### DIFF
--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -120,6 +120,7 @@ func init() {
 	agentCmd.Flags().StringP("log-level", "l", "", "log level (trace, debug, info, warn, error)")
 	agentCmd.Flags().StringSlice("disk-include", []string{}, "additional disk mount points to monitor (e.g., /mnt/storage)")
 	agentCmd.Flags().StringSlice("disk-exclude", []string{}, "disk mount points to exclude from monitoring (e.g., /boot)")
+	agentCmd.Flags().Bool("disable-system-metrics", false, "disable system metrics collection (CPU, memory, disk, temperature)")
 	agentCmd.Flags().Bool("tailscale", false, "enable Tailscale for secure connectivity")
 	agentCmd.Flags().String("tailscale-hostname", "", "custom Tailscale hostname (default: netronome-agent-<hostname>)")
 	agentCmd.Flags().String("tailscale-auth-key", "", "Tailscale auth key for automatic registration")
@@ -485,6 +486,9 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("disk-exclude") {
 		cfg.Agent.DiskExcludes = diskExcludes
+	}
+	if cmd.Flags().Changed("disable-system-metrics") {
+		cfg.Agent.DisableSystemMetrics, _ = cmd.Flags().GetBool("disable-system-metrics")
 	}
 
 	// Handle Tailscale flags

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -82,6 +82,10 @@ func (a *Agent) Start(ctx context.Context) error {
 		}
 	}()
 
+	if a.config.DisableSystemMetrics {
+		log.Info().Msg("System metrics collection disabled, running in bandwidth-only mode")
+	}
+
 	if a.config.APIKey != "" {
 		log.Info().Str("addr", addr).Msg("Starting monitor SSE agent with API key authentication")
 	} else {

--- a/internal/agent/routes.go
+++ b/internal/agent/routes.go
@@ -40,14 +40,14 @@ func (a *Agent) setupRoutes() *gin.Engine {
 	// Historical data export endpoint (protected)
 	protected.GET("/export/historical", a.handleHistoricalExport)
 
-	// System info endpoint (protected)
-	protected.GET("/system/info", a.handleSystemInfo)
+	// System info and hardware endpoints (protected, unless disabled)
+	if !a.config.DisableSystemMetrics {
+		protected.GET("/system/info", a.handleSystemInfo)
+		protected.GET("/system/hardware", a.handleHardwareStats)
+	}
 
 	// Peak stats endpoint (protected)
 	protected.GET("/stats/peaks", a.handlePeakStats)
-
-	// Hardware stats endpoint (protected)
-	protected.GET("/system/hardware", a.handleHardwareStats)
 
 	// Tailscale status endpoint (protected)
 	protected.GET("/tailscale/status", a.handleTailscaleStatus)
@@ -57,18 +57,22 @@ func (a *Agent) setupRoutes() *gin.Engine {
 
 // handleRoot handles the root endpoint
 func (a *Agent) handleRoot(c *gin.Context) {
+	endpoints := gin.H{
+		"live":       "/events?stream=live-data",
+		"historical": "/export/historical",
+		"peaks":      "/stats/peaks",
+		"tailscale":  "/tailscale/status",
+	}
+	if !a.config.DisableSystemMetrics {
+		endpoints["system"] = "/system/info"
+		endpoints["hardware"] = "/system/hardware"
+	}
+
 	response := gin.H{
-		"service": "monitor SSE agent",
-		"host":    a.config.Host,
-		"port":    a.config.Port,
-		"endpoints": gin.H{
-			"live":       "/events?stream=live-data",
-			"historical": "/export/historical",
-			"system":     "/system/info",
-			"hardware":   "/system/hardware",
-			"peaks":      "/stats/peaks",
-			"tailscale":  "/tailscale/status",
-		},
+		"service":   "monitor SSE agent",
+		"host":      a.config.Host,
+		"port":      a.config.Port,
+		"endpoints": endpoints,
 	}
 
 	// Indicate if authentication is required
@@ -86,10 +90,7 @@ func (a *Agent) handleRoot(c *gin.Context) {
 func (a *Agent) handleInfo(c *gin.Context) {
 	hostname, _ := os.Hostname()
 
-	usingTailscale := false
-	if a.tailscaleConfig != nil && a.tailscaleConfig.Enabled {
-		usingTailscale = true
-	}
+	usingTailscale := a.tailscaleConfig != nil && a.tailscaleConfig.Enabled
 
 	c.JSON(http.StatusOK, gin.H{
 		"type":            "netronome-agent",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,12 +136,13 @@ type PacketLossConfig struct {
 }
 
 type AgentConfig struct {
-	Host         string   `toml:"host" env:"AGENT_HOST"`
-	Port         int      `toml:"port" env:"AGENT_PORT"`
-	Interface    string   `toml:"interface" env:"AGENT_INTERFACE"`
-	APIKey       string   `toml:"api_key" env:"AGENT_API_KEY"`
-	DiskIncludes []string `toml:"disk_includes" env:"AGENT_DISK_INCLUDES" envSeparator:","`
-	DiskExcludes []string `toml:"disk_excludes" env:"AGENT_DISK_EXCLUDES" envSeparator:","`
+	Host                 string   `toml:"host" env:"AGENT_HOST"`
+	Port                 int      `toml:"port" env:"AGENT_PORT"`
+	Interface            string   `toml:"interface" env:"AGENT_INTERFACE"`
+	APIKey               string   `toml:"api_key" env:"AGENT_API_KEY"`
+	DiskIncludes         []string `toml:"disk_includes" env:"AGENT_DISK_INCLUDES" envSeparator:","`
+	DiskExcludes         []string `toml:"disk_excludes" env:"AGENT_DISK_EXCLUDES" envSeparator:","`
+	DisableSystemMetrics bool     `toml:"disable_system_metrics" env:"AGENT_DISABLE_SYSTEM_METRICS"`
 }
 
 type MonitorConfig struct {
@@ -625,6 +626,11 @@ func (c *Config) loadAgentFromEnv() {
 		c.Agent.DiskExcludes = strings.Split(v, ",")
 		for i := range c.Agent.DiskExcludes {
 			c.Agent.DiskExcludes[i] = strings.TrimSpace(c.Agent.DiskExcludes[i])
+		}
+	}
+	if v := getEnv("AGENT_DISABLE_SYSTEM_METRICS"); v != "" {
+		if disabled, err := strconv.ParseBool(v); err == nil {
+			c.Agent.DisableSystemMetrics = disabled
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `--disable-system-metrics` CLI flag, `NETRONOME__AGENT_DISABLE_SYSTEM_METRICS` env var, and `disable_system_metrics` TOML config option
- When enabled, the agent skips registering `/system/info` and `/system/hardware` endpoints, running in bandwidth-only mode
- Useful for agents deployed in VPN sidecars or similar environments where system metrics would be redundant with the host's metrics

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `netronome agent --disable-system-metrics` and verify `/system/info` and `/system/hardware` return 404
- [ ] Verify bandwidth monitoring and `/stats/peaks` still work normally
- [ ] Verify `NETRONOME__AGENT_DISABLE_SYSTEM_METRICS=true` env var works
- [ ] Verify `disable_system_metrics = true` in config TOML works

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to disable system metrics collection for bandwidth-only mode operation
  * System metrics endpoints are now conditionally available based on configuration settings
  * New flag and configuration option to control metrics collection behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->