### PR TITLE
fix(database): add _time_format=sqlite to DSN for proper timestamp scanning

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -221,7 +221,7 @@ func New(cfg config.DatabaseConfig) Service {
 			log.Fatal().Err(err).Msg("Failed to set database directory permissions")
 		}
 
-		db, err = sql.Open("sqlite", fmt.Sprintf("file:%s?cache=shared&mode=rwc&_foreign_keys=on", cfg.Path))
+		db, err = sql.Open("sqlite", fmt.Sprintf("file:%s?cache=shared&mode=rwc&_foreign_keys=on&_time_format=sqlite", cfg.Path))
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to open SQLite database")
 		}


### PR DESCRIPTION
## Summary

- Adds `_time_format=sqlite` to the SQLite DSN string, enabling the driver's built-in time parsing for all timestamp columns
- Fixes scan errors where SQLite stores `TIMESTAMP` columns as strings but Go code expects `time.Time`
- Works globally for all queries, not just specific functions

## Details

The `modernc.org/sqlite` driver supports a `_time_format` DSN parameter that controls how `time.Time` values are written and read. Without it, the driver returns raw strings on read, causing scan failures when the application expects `time.Time`.

Setting `_time_format=sqlite` tells the driver to:
1. Write times in SQLite-compatible format
2. Parse timestamp strings back into `time.Time` on scan using its built-in format list

The driver's parser covers both SQLite's `CURRENT_TIMESTAMP` format and Go's default time string format, so existing data remains compatible.

This supersedes #152, which works around the same issue by manually parsing timestamps in `GetMonitorAgent` and `GetMonitorAgents`. This DSN-level fix is preferable because it handles all tables/queries globally without duplicating parsing logic.

## Sources

- Driver `_time_format` parameter: https://pkg.go.dev/modernc.org/sqlite#hdr-Supported_DSN_query_parameters
- Driver time parsing formats: https://gitlab.com/cznic/sqlite/-/blob/master/sqlite.go (see `parseTimeFormats`)

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/database/...` passes
- [ ] Manual verification: run with SQLite, create a monitor agent, confirm timestamps in API responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database time formatting configuration to ensure consistent timestamp handling across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->