### PR TITLE
feat(speedtest): allow scheduling without specifying a server

### DIFF
--- a/internal/database/schedule.go
+++ b/internal/database/schedule.go
@@ -14,7 +14,25 @@ import (
 	"github.com/autobrr/netronome/internal/types"
 )
 
+func hasServerIDs(schedule types.Schedule) bool {
+	return len(schedule.ServerIDs) > 0 || len(schedule.Options.ServerIDs) > 0
+}
+
+func validateScheduleServerIDs(schedule types.Schedule) error {
+	if schedule.Options.UseIperf && schedule.Options.ServerHost == "" && !hasServerIDs(schedule) {
+		return fmt.Errorf("%w: iperf3 schedules require a server host or server ID", ErrInvalidInput)
+	}
+	if schedule.Options.UseLibrespeed && !hasServerIDs(schedule) {
+		return fmt.Errorf("%w: librespeed schedules require at least one server ID", ErrInvalidInput)
+	}
+	return nil
+}
+
 func (s *service) CreateSchedule(ctx context.Context, schedule types.Schedule) (*types.Schedule, error) {
+	if err := validateScheduleServerIDs(schedule); err != nil {
+		return nil, err
+	}
+
 	if schedule.ServerIDs == nil {
 		schedule.ServerIDs = []string{}
 	}
@@ -117,6 +135,10 @@ func (s *service) GetSchedules(ctx context.Context) ([]types.Schedule, error) {
 func (s *service) UpdateSchedule(ctx context.Context, schedule types.Schedule) error {
 	if schedule.ID <= 0 {
 		return fmt.Errorf("%w: invalid schedule ID", ErrInvalidInput)
+	}
+
+	if err := validateScheduleServerIDs(schedule); err != nil {
+		return err
 	}
 
 	if schedule.ServerIDs == nil {

--- a/internal/database/schedule_integration_test.go
+++ b/internal/database/schedule_integration_test.go
@@ -26,6 +26,7 @@ func TestSchedule_CRUD(t *testing.T) {
 			Enabled:   true,
 			Options: types.TestOptions{
 				UseIperf:       true,
+				ServerHost:     "iperf.example.com",
 				EnableDownload: true,
 				EnableUpload:   true,
 			},
@@ -97,6 +98,7 @@ func TestSchedule_MultipleSchedules(t *testing.T) {
 				Enabled:   true,
 				Options: types.TestOptions{
 					UseIperf:       true,
+					ServerHost:     "iperf.example.com",
 					EnableDownload: true,
 					EnableUpload:   true,
 				},
@@ -161,7 +163,7 @@ func TestSchedule_UpdateNonExistent(t *testing.T) {
 			Interval:  "1h",
 			NextRun:   time.Now(),
 			Enabled:   true,
-			Options:   types.TestOptions{UseIperf: true},
+			Options:   types.TestOptions{UseIperf: true, ServerHost: "iperf.example.com"},
 		}
 
 		err := td.Service.UpdateSchedule(ctx, nonExistent)
@@ -193,6 +195,7 @@ func TestSchedule_DifferentTestTypes(t *testing.T) {
 				"iperf3",
 				types.TestOptions{
 					UseIperf:       true,
+					ServerHost:     "iperf.example.com",
 					EnableDownload: true,
 					EnableUpload:   true,
 				},
@@ -298,6 +301,7 @@ func TestSchedule_TimestampBehavior(t *testing.T) {
 			Enabled:   true,
 			Options: types.TestOptions{
 				UseIperf:       true,
+				ServerHost:     "iperf.example.com",
 				EnableDownload: true,
 				EnableUpload:   true,
 			},
@@ -329,5 +333,167 @@ func TestSchedule_TimestampBehavior(t *testing.T) {
 		// NextRun should be updated
 		assert.NotEqual(t, originalNextRun.Unix(), schedules[0].NextRun.Unix(),
 			"NextRun should be different after update")
+	})
+}
+
+func TestSchedule_ServerIDValidation(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		ctx := context.Background()
+
+		t.Run("iperf3 without server host or IDs rejected", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: nil,
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseIperf:       true,
+					EnableDownload: true,
+				},
+			}
+
+			_, err := td.Service.CreateSchedule(ctx, schedule)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidInput)
+		})
+
+		t.Run("iperf3 with server host accepted", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: nil,
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseIperf:       true,
+					ServerHost:     "iperf.example.com",
+					EnableDownload: true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+			assert.NotNil(t, created)
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
+
+		t.Run("iperf3 with server IDs accepted", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: []string{"srv-1"},
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseIperf:       true,
+					EnableDownload: true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+			assert.NotNil(t, created)
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
+
+		t.Run("librespeed without server IDs rejected", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: nil,
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseLibrespeed:  true,
+					EnableDownload: true,
+				},
+			}
+
+			_, err := td.Service.CreateSchedule(ctx, schedule)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidInput)
+		})
+
+		t.Run("librespeed with server IDs accepted", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: []string{"ls-srv-1"},
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseLibrespeed:  true,
+					EnableDownload: true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+			assert.NotNil(t, created)
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
+
+		t.Run("speedtest.net without server IDs accepted", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: nil,
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					EnableDownload: true,
+					EnableUpload:   true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+			assert.NotNil(t, created)
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
+
+		t.Run("update iperf3 to empty server rejected", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: []string{"srv-1"},
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseIperf:       true,
+					EnableDownload: true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+
+			created.ServerIDs = nil
+			created.Options.ServerHost = ""
+			created.Options.ServerIDs = nil
+			err = td.Service.UpdateSchedule(ctx, *created)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidInput)
+
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
+
+		t.Run("update librespeed to empty server rejected", func(t *testing.T) {
+			schedule := types.Schedule{
+				ServerIDs: []string{"ls-srv-1"},
+				Interval:  "1h",
+				NextRun:   time.Now().Add(1 * time.Hour),
+				Enabled:   true,
+				Options: types.TestOptions{
+					UseLibrespeed:  true,
+					EnableDownload: true,
+				},
+			}
+
+			created, err := td.Service.CreateSchedule(ctx, schedule)
+			require.NoError(t, err)
+
+			created.ServerIDs = nil
+			created.Options.ServerIDs = nil
+			err = td.Service.UpdateSchedule(ctx, *created)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidInput)
+
+			_ = td.Service.DeleteSchedule(ctx, created.ID)
+		})
 	})
 }

--- a/web/src/components/speedtest/ScheduleManager.tsx
+++ b/web/src/components/speedtest/ScheduleManager.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react";
-import { Schedule, Server, SavedIperfServer } from "@/types/types";
+import { type ReactNode, useState, useEffect } from "react";
+import { type Schedule, type Server, type SavedIperfServer, type TestType } from "@/types/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getSchedules } from "@/api/speedtest";
 import { showToast } from "@/components/common/Toast";
@@ -48,7 +48,7 @@ import { Button } from "@/components/ui/Button";
 interface ScheduleManagerProps {
   servers: Server[];
   selectedServers: Server[];
-  onServerSelect: (server: Server) => void;
+  testType: TestType;
 }
 
 interface IntervalOption {
@@ -182,10 +182,7 @@ const formatExactTimeFromUTC = (time: string): string => {
   return formatTimeWithSettings(candidate);
 };
 
-export default function ScheduleManager({
-  servers,
-  selectedServers,
-}: ScheduleManagerProps) {
+export default function ScheduleManager({ servers, selectedServers, testType }: ScheduleManagerProps) {
   const queryClient = useQueryClient();
   const [iperfServers, setIperfServers] = useState<SavedIperfServer[]>([]);
   const [interval, setInterval] = useState<string>("1h");
@@ -281,11 +278,55 @@ export default function ScheduleManager({
     }
   };
 
+  const requiresServerSelection = testType === "iperf" || testType === "librespeed";
+  const isMissingServer = requiresServerSelection && selectedServers.length === 0;
+  const isMissingTime = scheduleType === "exact" && exactTimes.length === 0;
+  const isCreateDisabled = isMissingServer || isMissingTime;
+
+  function getScheduleDescription(): string {
+    if (scheduleType === "interval") {
+      return intervalOptions.find((opt) => opt.value === interval)?.label || interval;
+    }
+    if (exactTimes.length === 1) {
+      return `Daily at ${timeOptions.find((opt) => opt.value === exactTimes[0])?.label}`;
+    }
+    return `Daily at ${exactTimes.length} times`;
+  }
+
+  function renderButtonContent(): ReactNode {
+    if (isMissingServer) {
+      const label = testType === "iperf" ? "iperf3" : "LibreSpeed";
+      return <>Select a {label} server</>;
+    }
+    if (isMissingTime) {
+      return <>Select at least one time</>;
+    }
+
+    const icon = scheduleType === "interval"
+      ? <ArrowPathIcon className="w-5 h-5" />
+      : <ClockIcon className="w-5 h-5" />;
+
+    return (
+      <>
+        {icon}
+        <span>Create {getScheduleDescription()}</span>
+      </>
+    );
+  }
+
   const handleCreateSchedule = async () => {
     setError(null);
 
-    const isIperfServer = selectedServers.length > 0 && selectedServers[0].isIperf;
-    const isLibrespeedServer = selectedServers.length > 0 && selectedServers[0].isLibrespeed;
+    if (isMissingServer) {
+      const label = testType === "iperf" ? "iperf3" : "LibreSpeed";
+      const msg = `Please select a ${label} server before creating a schedule`;
+      setError(msg);
+      showToast(msg, "error");
+      return;
+    }
+
+    const isIperfServer = selectedServers[0]?.isIperf ?? false;
+    const isLibrespeedServer = selectedServers[0]?.isLibrespeed ?? false;
 
     // Get user's timezone for conversion
     const timeSettings = getTimeFormatSettings();
@@ -293,13 +334,9 @@ export default function ScheduleManager({
       ? Intl.DateTimeFormat().resolvedOptions().timeZone
       : timeSettings.timezone;
 
-    // Convert exact times from user timezone to UTC for backend storage
-    let scheduleTimes = exactTimes;
-    if (scheduleType === "exact") {
-      scheduleTimes = exactTimes.map(time =>
-        convertUserTimeToUTC(time, userTimezone)
-      );
-    }
+    const scheduleTimes = scheduleType === "exact"
+      ? exactTimes.map(time => convertUserTimeToUTC(time, userTimezone))
+      : exactTimes;
 
     const newSchedule: Schedule = {
       serverIds: selectedServers.map((s) => s.id),
@@ -314,7 +351,7 @@ export default function ScheduleManager({
         useLibrespeed: isLibrespeedServer,
         serverHost: isIperfServer ? selectedServers[0].host : undefined,
         serverName: isIperfServer ? selectedServers[0].name : undefined,
-        isPublicServer: isLibrespeedServer ? (selectedServers[0]?.isPublic ?? false) : false,
+        isPublicServer: isLibrespeedServer && (selectedServers[0]?.isPublic ?? false),
       },
     };
 
@@ -335,16 +372,9 @@ export default function ScheduleManager({
       }
 
       await response.json();
-      // Invalidate and refetch schedules
       queryClient.invalidateQueries({ queryKey: ["schedules"] });
-      
-      // Show success toast
-      const scheduleDescription = scheduleType === "exact" 
-        ? `Daily at ${exactTimes.length === 1 ? timeOptions.find(opt => opt.value === exactTimes[0])?.label : `${exactTimes.length} times`}`
-        : intervalOptions.find(opt => opt.value === interval)?.label || interval;
-      
       showToast("Schedule created successfully", "success", {
-        description: scheduleDescription
+        description: getScheduleDescription()
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to create schedule";
@@ -728,43 +758,14 @@ export default function ScheduleManager({
                           <div className="mt-6">
                             <Button
                               className={`w-full px-4 py-3 rounded-lg font-medium transition-all duration-200 ${
-                                (scheduleType === "exact" &&
-                                  exactTimes.length === 0)
+                                isCreateDisabled
                                   ? "bg-gray-300/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-500 cursor-not-allowed border border-gray-400 dark:border-gray-900"
                                   : "bg-blue-500 hover:bg-blue-600 text-white shadow-lg border border-blue-600 hover:border-blue-700 hover:shadow-xl"
                               }`}
                               onClick={handleCreateSchedule}
-                              disabled={
-                                scheduleType === "exact" &&
-                                  exactTimes.length === 0
-                              }
+                              disabled={isCreateDisabled}
                             >
-                              {scheduleType === "exact" &&
-                                exactTimes.length === 0 ? (
-                                <>Select at least one time</>
-                              ) : (
-                                <>
-                                  {scheduleType === "interval" ? (
-                                    <ArrowPathIcon className="w-5 h-5" />
-                                  ) : (
-                                    <ClockIcon className="w-5 h-5" />
-                                  )}
-                                  <span>
-                                    Create{" "}
-                                    {scheduleType === "interval"
-                                      ? intervalOptions.find(
-                                          (opt) => opt.value === interval
-                                        )?.label
-                                      : exactTimes.length === 1
-                                      ? `Daily at ${
-                                          timeOptions.find(
-                                            (opt) => opt.value === exactTimes[0]
-                                          )?.label
-                                        }`
-                                      : `Daily at ${exactTimes.length} times`}
-                                  </span>
-                                </>
-                              )}
+                              {renderButtonContent()}
                             </Button>
                           </div>
                         </div>

--- a/web/src/components/speedtest/SpeedTestTab.tsx
+++ b/web/src/components/speedtest/SpeedTestTab.tsx
@@ -73,7 +73,7 @@ export const SpeedTestTab: React.FC<SpeedTestTabProps> = ({
         <ScheduleManager
           servers={allServers}
           selectedServers={selectedServers}
-          onServerSelect={onServerSelect}
+          testType={testType}
         />
       </motion.div>
     </div>


### PR DESCRIPTION
## Summary

- Removes the requirement to select a server when creating a speedtest.net schedule
- When no server is specified, the backend automatically selects the closest server by geographic distance (existing behavior in the speedtest.net runner)
- Displays "Closest server (auto)" in the schedule list for schedules without a specific server
- iperf3 and LibreSpeed schedules still require a server since they have no auto-selection fallback

Closes #128

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./...` passes
- [x] `pnpm tsc --noEmit` passes (no type errors)
- [ ] Create a schedule without selecting any server - verify it creates successfully
- [ ] Verify the schedule displays "Closest server (auto)" in the active schedules list
- [ ] Verify the scheduled test runs and picks the closest server
- [ ] Verify selecting a specific server still works as before
- [ ] Verify the "Next run" preview shows without server selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved schedule creation UI: clearer button states, descriptive schedule text, and a green "Closest server (auto)" indicator when no servers are selected.
  * Schedules can rely on a server host configuration in addition to explicit server selection.

* **Bug Fixes**
  * Client-side validation tightened: prevents creating invalid schedules and shows helpful error toasts.
  * Next Run preview and exact-time handling behave more predictably across schedule types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->