### PR TITLE
fix(server): remove EnsureConfig to prevent permission denied in Docker

### DIFF
--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -208,9 +208,10 @@ func runServer(cmd *cobra.Command, args []string) error {
 		if configPath != "" {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
-		logger.Init(config.LoggingConfig{Level: "info"}, config.ServerConfig{}, false)
-		log.Warn().Err(err).Msg("Failed to load config, using defaults")
 		cfg = config.New()
+		cfg.ApplyEnv()
+		logger.Init(cfg.Logging, cfg.Server, false)
+		log.Warn().Err(err).Msg("Failed to load config, using defaults with environment overrides")
 	}
 
 	// reinitialize logger with loaded config (not silent)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -387,6 +387,13 @@ func Load(configPath string) (*Config, error) {
 	return cfg, nil
 }
 
+// ApplyEnv loads configuration from environment variables.
+// This is useful when no config file is available and you want to apply
+// environment variable overrides to a default config.
+func (c *Config) ApplyEnv() {
+	c.loadFromEnv()
+}
+
 // loadFromEnv loads configuration from environment variables
 func (c *Config) loadFromEnv() error {
 	c.loadDatabaseFromEnv()


### PR DESCRIPTION
## Summary
- Removes `EnsureConfig()` call from `runServer`, which attempted to create the config file and failed with "permission denied" in Docker containers without write access
- Replaces the `EnsureConfig()` + `Load()` two-step pattern with just `Load()`, matching the agent command pattern (PR #171)
- When `--config` is explicitly specified and fails to load, still returns an error; otherwise falls back to defaults + env vars

## Behavior After Fix
| Scenario | Before | After |
|----------|--------|-------|
| No config flag, no config file | Permission denied | Starts with defaults + env vars |
| No config flag, config at default path | Loads it | Loads it |
| `--config /path` specified | Loads it | Loads it (errors if missing) |
| Env vars (`NETRONOME__*`) | Applied after file load | Always applied as overrides |

Closes #140

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `pnpm tsc --noEmit` passes
- [ ] Docker container without config file starts successfully using env vars
- [ ] Docker container with mounted config file still works
- [ ] `--config /nonexistent` correctly returns an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading: explicit error returned when a provided config path fails to load; when no path is given, the app falls back to defaults and applies environment overrides.
  * Logger initialization updated to reflect loaded/default configuration and now emits a warning when running with defaults plus env overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->