### PR TITLE
fix: show newest speedtest in Latest Run

### DIFF
--- a/web/src/components/speedtest/DashboardTab.tsx
+++ b/web/src/components/speedtest/DashboardTab.tsx
@@ -229,7 +229,7 @@ export const DashboardTab: React.FC<DashboardTabProps> = ({
 
   // Get the latest test from filtered results
   const filteredLatestTestComputed = useMemo(() => {
-    return filteredDisplayTests.length > 0 ? filteredDisplayTests[filteredDisplayTests.length - 1] : null;
+    return filteredDisplayTests.length > 0 ? filteredDisplayTests[0] : null;
   }, [filteredDisplayTests]);
 
   const calculateAverage = (field: keyof SpeedTestResult): string => {


### PR DESCRIPTION
Latest Run metrics now use the newest filtered test.

fixes #182 