### PR TITLE
fix(monitor): stop polling disabled system metrics endpoints

### DIFF
--- a/internal/monitor/capabilities.go
+++ b/internal/monitor/capabilities.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type agentEndpoint int
+
+const (
+	endpointSystemInfo agentEndpoint = iota
+	endpointHardwareStats
+)
+
+type endpointSupport struct {
+	known     bool
+	supported bool
+}
+
+type agentCapabilities struct {
+	systemInfo    endpointSupport
+	hardwareStats endpointSupport
+}
+
+type httpStatusError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e *httpStatusError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("unexpected status code: %d (url=%s)", e.StatusCode, e.URL)
+}
+
+func detectAgentCapabilities(ctx context.Context, baseURL string) (agentCapabilities, error) {
+	rootURL := strings.TrimRight(baseURL, "/") + "/"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rootURL, nil)
+	if err != nil {
+		return agentCapabilities{}, fmt.Errorf("create root request: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return agentCapabilities{}, fmt.Errorf("fetch root: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return agentCapabilities{}, &httpStatusError{StatusCode: resp.StatusCode, URL: rootURL}
+	}
+
+	var root struct {
+		Endpoints map[string]any `json:"endpoints"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&root); err != nil {
+		return agentCapabilities{}, fmt.Errorf("decode root json: %w", err)
+	}
+	if root.Endpoints == nil {
+		return agentCapabilities{}, fmt.Errorf("root response missing endpoints")
+	}
+
+	_, hasSystem := root.Endpoints["system"]
+	_, hasHardware := root.Endpoints["hardware"]
+
+	return agentCapabilities{
+		systemInfo:    endpointSupport{known: true, supported: hasSystem},
+		hardwareStats: endpointSupport{known: true, supported: hasHardware},
+	}, nil
+}

--- a/internal/monitor/capabilities_test.go
+++ b/internal/monitor/capabilities_test.go
@@ -1,0 +1,83 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+func TestDetectAgentCapabilities_FromRootEndpoints(t *testing.T) {
+	t.Run("has system+hardware", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"endpoints":{"system":"/system/info","hardware":"/system/hardware"}}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		caps, err := detectAgentCapabilities(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("detectAgentCapabilities error: %v", err)
+		}
+		if !caps.systemInfo.known || !caps.systemInfo.supported {
+			t.Fatalf("systemInfo expected known+supported, got %+v", caps.systemInfo)
+		}
+		if !caps.hardwareStats.known || !caps.hardwareStats.supported {
+			t.Fatalf("hardwareStats expected known+supported, got %+v", caps.hardwareStats)
+		}
+	})
+
+	t.Run("missing system+hardware", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"endpoints":{"live":"/events?stream=live-data"}}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		caps, err := detectAgentCapabilities(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("detectAgentCapabilities error: %v", err)
+		}
+		if !caps.systemInfo.known || caps.systemInfo.supported {
+			t.Fatalf("systemInfo expected known+unsupported, got %+v", caps.systemInfo)
+		}
+		if !caps.hardwareStats.known || caps.hardwareStats.supported {
+			t.Fatalf("hardwareStats expected known+unsupported, got %+v", caps.hardwareStats)
+		}
+	})
+
+	t.Run("missing endpoints field", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"service":"monitor SSE agent"}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := detectAgentCapabilities(context.Background(), srv.URL)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+}
+
+func TestClient_HandleEndpointNotFound_DisablesPolling(t *testing.T) {
+	c := &Client{
+		agent: &types.MonitorAgent{
+			ID:  123,
+			URL: "http://example.invalid/events?stream=live-data",
+		},
+	}
+
+	if !c.shouldPollSystemInfo() {
+		t.Fatalf("expected system info polling enabled by default")
+	}
+
+	if !c.handleEndpointNotFound(&httpStatusError{StatusCode: http.StatusNotFound, URL: "http://x/system/info"}, endpointSystemInfo) {
+		t.Fatalf("expected handleEndpointNotFound=true")
+	}
+	if c.shouldPollSystemInfo() {
+		t.Fatalf("expected system info polling disabled after 404")
+	}
+}

--- a/internal/monitor/client.go
+++ b/internal/monitor/client.go
@@ -40,6 +40,9 @@ type Client struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 
+	capsOnce sync.Once
+	caps     agentCapabilities
+
 	// Peak tracking
 	peakRx          int64
 	peakTx          int64
@@ -346,6 +349,82 @@ func (c *Client) IsConnected() (bool, *types.MonitorLiveData) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.connected, c.lastData
+}
+
+func (c *Client) baseURL() string {
+	return strings.TrimSuffix(c.agent.URL, "/events?stream=live-data")
+}
+
+func (c *Client) ensureCapabilities() {
+	c.capsOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		caps, err := detectAgentCapabilities(ctx, c.baseURL())
+		if err != nil {
+			// Unknown capabilities -> keep legacy behavior (poll endpoints).
+			log.Debug().Err(err).Int64("agent_id", c.agent.ID).Msg("Failed to detect agent capabilities")
+			return
+		}
+
+		c.mu.Lock()
+		c.caps = caps
+		c.mu.Unlock()
+	})
+}
+
+func (c *Client) shouldPollSystemInfo() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.caps.systemInfo.known {
+		return c.caps.systemInfo.supported
+	}
+	return true
+}
+
+func (c *Client) shouldPollHardwareStats() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.caps.hardwareStats.known {
+		return c.caps.hardwareStats.supported
+	}
+	return true
+}
+
+func (c *Client) handleEndpointNotFound(err error, ep agentEndpoint) bool {
+	var statusErr *httpStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	if statusErr.StatusCode != http.StatusNotFound {
+		return false
+	}
+
+	var msg string
+	c.mu.Lock()
+	switch ep {
+	case endpointSystemInfo:
+		if c.caps.systemInfo.known && !c.caps.systemInfo.supported {
+			c.mu.Unlock()
+			return true
+		}
+		c.caps.systemInfo = endpointSupport{known: true, supported: false}
+		msg = "System info endpoint not available (404); disabling polling for this agent"
+	case endpointHardwareStats:
+		if c.caps.hardwareStats.known && !c.caps.hardwareStats.supported {
+			c.mu.Unlock()
+			return true
+		}
+		c.caps.hardwareStats = endpointSupport{known: true, supported: false}
+		msg = "Hardware stats endpoint not available (404); disabling polling for this agent"
+	default:
+		c.mu.Unlock()
+		return false
+	}
+	c.mu.Unlock()
+
+	log.Info().Int64("agent_id", c.agent.ID).Msg(msg)
+	return true
 }
 
 // monitor connects to the SSE endpoint and processes data
@@ -677,21 +756,28 @@ func (s *Service) collectResourceStats() {
 
 // fetchAndStoreResourceStats fetches system info and hardware stats from an agent
 func (s *Service) fetchAndStoreResourceStats(client *Client) {
-	// Fetch system info
-	if err := s.fetchSystemInfo(client); err != nil {
-		log.Error().Err(err).Int64("agent_id", client.agent.ID).Msg("Failed to fetch system info")
+	client.ensureCapabilities()
+
+	if client.shouldPollSystemInfo() {
+		if err := s.fetchSystemInfo(client); err != nil {
+			if !client.handleEndpointNotFound(err, endpointSystemInfo) {
+				log.Error().Err(err).Int64("agent_id", client.agent.ID).Msg("Failed to fetch system info")
+			}
+		}
 	}
 
-	// Fetch hardware stats
-	if err := s.fetchHardwareStats(client); err != nil {
-		log.Error().Err(err).Int64("agent_id", client.agent.ID).Msg("Failed to fetch hardware stats")
+	if client.shouldPollHardwareStats() {
+		if err := s.fetchHardwareStats(client); err != nil {
+			if !client.handleEndpointNotFound(err, endpointHardwareStats) {
+				log.Error().Err(err).Int64("agent_id", client.agent.ID).Msg("Failed to fetch hardware stats")
+			}
+		}
 	}
 }
 
 // fetchSystemInfo fetches and stores system information from an agent
 func (s *Service) fetchSystemInfo(client *Client) error {
-	baseURL := strings.TrimSuffix(client.agent.URL, "/events?stream=live-data")
-	systemURL := baseURL + "/system/info"
+	systemURL := strings.TrimRight(client.baseURL(), "/") + "/system/info"
 
 	req, err := http.NewRequestWithContext(client.ctx, "GET", systemURL, nil)
 	if err != nil {
@@ -710,7 +796,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return &httpStatusError{StatusCode: resp.StatusCode, URL: systemURL}
 	}
 
 	// Read the response body first for debugging
@@ -740,7 +826,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 
 	// Fetch agent version from /netronome/info endpoint
 	agentVersion := ""
-	infoURL := baseURL + "/netronome/info"
+	infoURL := strings.TrimRight(client.baseURL(), "/") + "/netronome/info"
 	infoReq, err := http.NewRequestWithContext(client.ctx, "GET", infoURL, nil)
 	if err == nil {
 		// Don't add API key for this endpoint as it's public
@@ -811,8 +897,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 
 // fetchHardwareStats fetches and stores hardware statistics from an agent
 func (s *Service) fetchHardwareStats(client *Client) error {
-	baseURL := strings.TrimSuffix(client.agent.URL, "/events?stream=live-data")
-	hardwareURL := baseURL + "/system/hardware"
+	hardwareURL := strings.TrimRight(client.baseURL(), "/") + "/system/hardware"
 
 	req, err := http.NewRequestWithContext(client.ctx, "GET", hardwareURL, nil)
 	if err != nil {
@@ -831,7 +916,7 @@ func (s *Service) fetchHardwareStats(client *Client) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return &httpStatusError{StatusCode: resp.StatusCode, URL: hardwareURL}
 	}
 
 	var hardwareStats struct {


### PR DESCRIPTION
Stops log spam when an agent disables system metrics endpoints.

- Detect supported endpoints via agent root (/) and skip polling when system/hardware endpoints are absent
- If /system/info or /system/hardware returns 404, log once and disable further polling for that agent

Ran: go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent capability detection automatically identifies supported monitoring endpoints, enabling intelligent conditional polling for system information and hardware statistics.

* **Improvements**
  * Enhanced error handling for unavailable endpoints with automatic polling adjustments when endpoints return 404 responses, reducing unnecessary requests and improving system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->