### PR TITLE
fix: persist dashboard recent speedtests row limit

### DIFF
--- a/internal/database/app_settings.go
+++ b/internal/database/app_settings.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+func (s *service) GetAppSetting(ctx context.Context, key string) (string, error) {
+	query := s.sqlBuilder.
+		Select("value").
+		From("app_settings").
+		Where(sq.Eq{"key": key})
+
+	var value string
+	err := query.RunWith(s.db).QueryRowContext(ctx).Scan(&value)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("failed to get app setting %q: %w", key, err)
+	}
+
+	return value, nil
+}
+
+func (s *service) SetAppSetting(ctx context.Context, key, value string) error {
+	result, err := s.update(ctx, "app_settings", map[string]interface{}{"value": value}, sq.Eq{"key": key})
+	if err != nil {
+		return fmt.Errorf("failed to update app setting %q: %w", key, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to inspect updated app setting %q: %w", key, err)
+	}
+
+	if rowsAffected > 0 {
+		return nil
+	}
+
+	if _, err := s.insert(ctx, "app_settings", map[string]interface{}{"key": key, "value": value}); err != nil {
+		return fmt.Errorf("failed to insert app setting %q: %w", key, err)
+	}
+
+	return nil
+}

--- a/internal/database/app_settings_integration_test.go
+++ b/internal/database/app_settings_integration_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppSettings_GetMissingReturnsNotFound(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		ctx := context.Background()
+
+		_, err := td.Service.GetAppSetting(ctx, "dashboard_recent_speedtests_rows")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestAppSettings_SetAndGet(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		ctx := context.Background()
+
+		err := td.Service.SetAppSetting(ctx, "dashboard_recent_speedtests_rows", "20")
+		require.NoError(t, err)
+
+		value, err := td.Service.GetAppSetting(ctx, "dashboard_recent_speedtests_rows")
+		require.NoError(t, err)
+		assert.Equal(t, "20", value)
+	})
+}
+
+func TestAppSettings_UpdateExisting(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		ctx := context.Background()
+
+		err := td.Service.SetAppSetting(ctx, "dashboard_recent_speedtests_rows", "20")
+		require.NoError(t, err)
+
+		err = td.Service.SetAppSetting(ctx, "dashboard_recent_speedtests_rows", "100")
+		require.NoError(t, err)
+
+		value, err := td.Service.GetAppSetting(ctx, "dashboard_recent_speedtests_rows")
+		require.NoError(t, err)
+		assert.Equal(t, "100", value)
+	})
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,6 +66,10 @@ type Service interface {
 	SaveSpeedTest(ctx context.Context, result types.SpeedTestResult) (*types.SpeedTestResult, error)
 	GetSpeedTests(ctx context.Context, timeRange string, page int, limit int) (*types.PaginatedSpeedTests, error)
 
+	// App settings operations
+	GetAppSetting(ctx context.Context, key string) (string, error)
+	SetAppSetting(ctx context.Context, key, value string) error
+
 	// Schedule operations
 	CreateSchedule(ctx context.Context, schedule types.Schedule) (*types.Schedule, error)
 	GetSchedules(ctx context.Context) ([]types.Schedule, error)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -180,6 +180,7 @@ var testTablesToClear = []string{
 	"notification_history",
 	"notification_rules",
 	"notification_channels",
+	"app_settings",
 	"packet_loss_results",
 	"packet_loss_monitors",
 	"monitor_historical_snapshots",
@@ -217,8 +218,8 @@ func resetSequences(t *testing.T, db *sql.DB) {
 
 	// Get all sequences in the database
 	rows, err := db.Query(`
-		SELECT schemaname, sequencename 
-		FROM pg_sequences 
+		SELECT schemaname, sequencename
+		FROM pg_sequences
 		WHERE schemaname = 'public'
 	`)
 	if err != nil {

--- a/internal/database/migrations/postgres/020_add_app_settings_postgres.sql
+++ b/internal/database/migrations/postgres/020_add_app_settings_postgres.sql
@@ -1,0 +1,20 @@
+-- Add application settings table for single-user persisted UI/server settings
+CREATE TABLE IF NOT EXISTS app_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION update_app_settings_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_app_settings_updated_at ON app_settings;
+CREATE TRIGGER update_app_settings_updated_at
+BEFORE UPDATE ON app_settings
+FOR EACH ROW EXECUTE FUNCTION update_app_settings_updated_at_column();

--- a/internal/database/migrations/sqlite/020_add_app_settings.sql
+++ b/internal/database/migrations/sqlite/020_add_app_settings.sql
@@ -1,0 +1,13 @@
+-- Add application settings table for single-user persisted UI/server settings
+CREATE TABLE IF NOT EXISTS app_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS update_app_settings_timestamp
+AFTER UPDATE ON app_settings
+BEGIN
+    UPDATE app_settings SET updated_at = CURRENT_TIMESTAMP WHERE key = NEW.key;
+END;

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -281,16 +281,19 @@ func (s *Server) RegisterRoutes() {
 			protected.POST("/notifications/channels", s.handleCreateNotificationChannel)
 			protected.PUT("/notifications/channels/:id", s.handleUpdateNotificationChannel)
 			protected.DELETE("/notifications/channels/:id", s.handleDeleteNotificationChannel)
-			
+
 			protected.GET("/notifications/events", s.handleGetNotificationEvents)
-			
+
 			protected.GET("/notifications/rules", s.handleGetNotificationRules)
 			protected.POST("/notifications/rules", s.handleCreateNotificationRule)
 			protected.PUT("/notifications/rules/:id", s.handleUpdateNotificationRule)
 			protected.DELETE("/notifications/rules/:id", s.handleDeleteNotificationRule)
-			
+
 			protected.POST("/notifications/test", s.handleTestNotification)
 			protected.GET("/notifications/history", s.handleGetNotificationHistory)
+
+			protected.GET("/settings/dashboard", s.handleGetDashboardSettings)
+			protected.PUT("/settings/dashboard", s.handleUpdateDashboardSettings)
 		}
 	}
 

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/netronome/internal/database"
+)
+
+const (
+	dashboardRecentRowsSettingKey = "dashboard_recent_speedtests_rows"
+	dashboardRecentRowsDefault    = 20
+)
+
+var allowedDashboardRecentRows = map[int]struct{}{
+	10:  {},
+	20:  {},
+	50:  {},
+	100: {},
+}
+
+type dashboardSettingsResponse struct {
+	RecentSpeedtestsRows int `json:"recentSpeedtestsRows"`
+}
+
+type updateDashboardSettingsRequest struct {
+	RecentSpeedtestsRows int `json:"recentSpeedtestsRows"`
+}
+
+func (s *Server) handleGetDashboardSettings(c *gin.Context) {
+	value, err := s.db.GetAppSetting(c.Request.Context(), dashboardRecentRowsSettingKey)
+	if err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: dashboardRecentRowsDefault})
+			return
+		}
+
+		log.Error().Err(err).Msg("Failed to get dashboard settings")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get dashboard settings"})
+		return
+	}
+
+	rows, err := strconv.Atoi(value)
+	if err != nil {
+		log.Warn().Err(err).Str("value", value).Msg("Invalid persisted dashboard row setting, using default")
+		c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: dashboardRecentRowsDefault})
+		return
+	}
+
+	if !isAllowedDashboardRecentRows(rows) {
+		log.Warn().Int("rows", rows).Msg("Out-of-range persisted dashboard row setting, using default")
+		c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: dashboardRecentRowsDefault})
+		return
+	}
+
+	c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: rows})
+}
+
+func (s *Server) handleUpdateDashboardSettings(c *gin.Context) {
+	var req updateDashboardSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	if !isAllowedDashboardRecentRows(req.RecentSpeedtestsRows) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "recentSpeedtestsRows must be one of: 10, 20, 50, 100"})
+		return
+	}
+
+	if err := s.db.SetAppSetting(c.Request.Context(), dashboardRecentRowsSettingKey, strconv.Itoa(req.RecentSpeedtestsRows)); err != nil {
+		log.Error().Err(err).Msg("Failed to update dashboard settings")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update dashboard settings"})
+		return
+	}
+
+	c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: req.RecentSpeedtestsRows})
+}
+
+func isAllowedDashboardRecentRows(rows int) bool {
+	_, ok := allowedDashboardRecentRows[rows]
+	return ok
+}

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getApiUrl } from "@/utils/baseUrl";
+
+type ApiErrorPayload = {
+  error?: string;
+  details?: string;
+  message?: string;
+};
+
+const parseErrorMessage = async (response: Response): Promise<string> => {
+  const text = await response.text().catch(() => "");
+  if (text) {
+    try {
+      const json = JSON.parse(text) as ApiErrorPayload;
+      const msg = json.details
+        ? `${json.error ?? "Request failed"}: ${json.details}`
+        : (json.error ?? json.message);
+      if (msg) return msg;
+    } catch {
+      // fall through: non-JSON error body
+    }
+    return text;
+  }
+  return response.statusText || `Request failed (${response.status})`;
+};
+
+const assertOk = async (response: Response, fallback: string) => {
+  if (response.ok) return;
+  const msg = await parseErrorMessage(response);
+  throw new Error(msg || fallback);
+};
+
+export interface DashboardSettings {
+  recentSpeedtestsRows: number;
+}
+
+export const settingsApi = {
+  getDashboardSettings: async (): Promise<DashboardSettings> => {
+    const response = await fetch(getApiUrl("/settings/dashboard"), {
+      credentials: "include",
+    });
+    await assertOk(response, "Failed to fetch dashboard settings");
+    return response.json();
+  },
+
+  updateDashboardSettings: async (
+    input: DashboardSettings
+  ): Promise<DashboardSettings> => {
+    const response = await fetch(getApiUrl("/settings/dashboard"), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(input),
+    });
+    await assertOk(response, "Failed to update dashboard settings");
+    return response.json();
+  },
+};

--- a/web/src/components/Main.tsx
+++ b/web/src/components/Main.tsx
@@ -44,6 +44,7 @@ import {
   getSpeedTestStatus,
   getPublicHistory,
 } from "@/api/speedtest";
+import { settingsApi } from "@/api/settings";
 import { motion, AnimatePresence } from "motion/react";
 
 interface MainProps {
@@ -139,11 +140,22 @@ export default function Main({ isPublic = false }: MainProps) {
     return speedtestServers;
   }, [testType, speedtestServers, librespeedServers]);
 
+  const { data: dashboardSettings } = useQuery({
+    queryKey: ["dashboard-settings"],
+    queryFn: settingsApi.getDashboardSettings,
+    enabled: !isPublic,
+    staleTime: 60_000,
+  });
+
+  const recentSpeedtestsRowsLimit = isPublic
+    ? 20
+    : dashboardSettings?.recentSpeedtestsRows ?? 20;
+
   const { data: historyData } = useInfiniteQuery({
-    queryKey: ["history", timeRange, isPublic],
+    queryKey: ["history", timeRange, isPublic, recentSpeedtestsRowsLimit],
     queryFn: async ({ pageParam = 1 }) => {
       const historyFn = isPublic ? getPublicHistory : getHistory;
-      const response = await historyFn(timeRange, pageParam, 20);
+      const response = await historyFn(timeRange, pageParam, recentSpeedtestsRowsLimit);
       return response as PaginatedResponse<SpeedTestResult>;
     },
     getNextPageParam: (
@@ -522,6 +534,7 @@ export default function Main({ isPublic = false }: MainProps) {
               <DashboardTab
                 latestTest={latestTest}
                 tests={history}
+                recentSpeedtestsRows={recentSpeedtestsRowsLimit}
                 timeRange={timeRange}
                 onTimeRangeChange={setTimeRange}
                 isPublic={isPublic}

--- a/web/src/components/SettingsMenu.tsx
+++ b/web/src/components/SettingsMenu.tsx
@@ -4,10 +4,17 @@
  */
 
 import React, { useState } from "react";
-import { Cog6ToothIcon, BellIcon, ClockIcon, MapPinIcon } from "@heroicons/react/24/outline";
+import {
+  Cog6ToothIcon,
+  BellIcon,
+  ClockIcon,
+  MapPinIcon,
+  PresentationChartLineIcon,
+} from "@heroicons/react/24/outline";
 import { NotificationSettings } from "./settings/NotificationSettings";
 import { TimeFormatSettings } from "./settings/TimeFormatSettings";
 import { DistanceSettings } from "./settings/DistanceSettings";
+import { DashboardSettings } from "./settings/DashboardSettings";
 import { Button } from "@/components/ui/Button";
 import {
   Dialog,
@@ -47,6 +54,12 @@ const settingsSections: SettingsSection[] = [
     label: "Distance Units",
     icon: <MapPinIcon className="w-4 h-4" />,
     component: DistanceSettings,
+  },
+  {
+    id: "dashboard",
+    label: "Dashboard",
+    icon: <PresentationChartLineIcon className="w-4 h-4" />,
+    component: DashboardSettings,
   },
 ];
 

--- a/web/src/components/settings/DashboardSettings.tsx
+++ b/web/src/components/settings/DashboardSettings.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import React, { useState } from "react";
+import { PresentationChartLineIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/Button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { settingsApi } from "@/api/settings";
+import { showToast } from "@/components/common/Toast";
+
+const ROW_OPTIONS = [10, 20, 50, 100];
+
+export const DashboardSettings: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["dashboard-settings"],
+    queryFn: settingsApi.getDashboardSettings,
+  });
+
+  const [pendingRows, setPendingRows] = useState<number | null>(null);
+  const persistedRows = data?.recentSpeedtestsRows ?? 20;
+  const selectedRows = pendingRows ?? persistedRows;
+  const hasChanges = pendingRows !== null && pendingRows !== persistedRows;
+
+  const mutation = useMutation({
+    mutationFn: settingsApi.updateDashboardSettings,
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["dashboard-settings"], updated);
+      queryClient.invalidateQueries({ queryKey: ["history"] });
+      setPendingRows(null);
+      showToast("Dashboard settings saved", "success", {
+        description: "Recent Speedtests row count updated",
+      });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : undefined;
+      showToast("Failed to save dashboard settings", "error", {
+        description: message,
+      });
+    },
+  });
+
+  const updateRecentRows = (value: string) => {
+    const parsedValue = Number(value);
+    setPendingRows(parsedValue);
+  };
+
+  const cancelChanges = () => {
+    setPendingRows(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[220px]">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-gray-300 dark:border-gray-700 border-t-blue-500 dark:border-t-blue-400 rounded-full mx-auto mb-4 animate-spin" />
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Loading dashboard settings...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h3 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <PresentationChartLineIcon className="w-6 h-6 text-gray-600 dark:text-gray-400" />
+            Dashboard Settings
+          </h3>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Configure recent speedtest history display behavior
+          </p>
+        </div>
+
+        {hasChanges && (
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={() =>
+                mutation.mutate({ recentSpeedtestsRows: selectedRows })
+              }
+              disabled={mutation.isPending}
+              className="bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              <CheckIcon className="w-4 h-4" />
+              Save Changes
+            </Button>
+            <Button onClick={cancelChanges} variant="secondary" disabled={mutation.isPending}>
+              Cancel
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <PresentationChartLineIcon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+            Recent Speedtests
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Rows shown on dashboard
+            </label>
+            <Select
+              value={String(selectedRows)}
+              onValueChange={updateRecentRows}
+            >
+              <SelectTrigger className="w-full sm:w-[240px]">
+                <SelectValue placeholder="Select row count" />
+              </SelectTrigger>
+              <SelectContent>
+                {ROW_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={String(option)}>
+                    {option} rows
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Controls how many recent speedtests are loaded and shown in Dashboard {'>'} Recent Speedtests.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/web/src/components/speedtest/DashboardTab.tsx
+++ b/web/src/components/speedtest/DashboardTab.tsx
@@ -57,6 +57,7 @@ import { formatDateTimeWithSettings, useTimeSettings } from "@/utils/timeSetting
 interface DashboardTabProps {
   latestTest: SpeedTestResult | null;
   tests: SpeedTestResult[];
+  recentSpeedtestsRows?: number;
   timeRange: TimeRange;
   onTimeRangeChange: (range: TimeRange) => void;
   isPublic?: boolean;
@@ -159,6 +160,7 @@ const DraggableSpeedHistoryChart: React.FC<DraggableSpeedHistoryChartProps> = ({
 export const DashboardTab: React.FC<DashboardTabProps> = ({
   latestTest,
   tests,
+  recentSpeedtestsRows = 20,
   timeRange,
   onTimeRangeChange,
   isPublic = false,
@@ -168,7 +170,7 @@ export const DashboardTab: React.FC<DashboardTabProps> = ({
   onNavigateToVnstat,
 }) => {
   const { settings } = useTimeSettings();
-  const [displayCount, setDisplayCount] = useState(5);
+  const [displayCount, setDisplayCount] = useState(recentSpeedtestsRows);
   const [isRecentTestsOpen, setIsRecentTestsOpen] = useState(() => {
     const saved = localStorage.getItem("recent-tests-open");
     return saved === null ? true : saved === "true";
@@ -214,6 +216,10 @@ export const DashboardTab: React.FC<DashboardTabProps> = ({
       JSON.stringify(sectionOrder)
     );
   }, [sectionOrder]);
+
+  useEffect(() => {
+    setDisplayCount(recentSpeedtestsRows);
+  }, [recentSpeedtestsRows]);
 
   const displayedTests = tests.slice(0, displayCount);
 
@@ -550,6 +556,7 @@ const DraggableRecentSpeedtests: React.FC<DraggableRecentSpeedtestsProps> = ({
                 columns={columns}
                 data={displayedTests}
                 showPagination={false}
+                pageSize={Math.max(displayedTests.length, 1)}
                 showColumnVisibility={true}
                 showRowSelection={false}
                 filterColumn="serverName"
@@ -564,6 +571,7 @@ const DraggableRecentSpeedtests: React.FC<DraggableRecentSpeedtestsProps> = ({
                 columns={mobileColumns}
                 data={displayedTests}
                 showPagination={false}
+                pageSize={Math.max(displayedTests.length, 1)}
                 showColumnVisibility={false}
                 showRowSelection={false}
                 showHeaders={false}


### PR DESCRIPTION
## Summary
- add DB-backed app setting storage () for single-user persisted dashboard preferences
- add protected API endpoints to read/update dashboard settings
- add new **Settings -> Dashboard** section with a row-count selector (10/20/50/100)
- use configured row limit when fetching dashboard history and fix hidden 10-row table cap when pagination controls are disabled

## Test commands
- ?   	github.com/autobrr/netronome/cmd/netronome	[no test files]
ok  	github.com/autobrr/netronome/internal/agent	(cached)
?   	github.com/autobrr/netronome/internal/auth	[no test files]
?   	github.com/autobrr/netronome/internal/broadcaster	[no test files]
ok  	github.com/autobrr/netronome/internal/config	(cached)
ok  	github.com/autobrr/netronome/internal/database	18.347s
?   	github.com/autobrr/netronome/internal/database/migrations	[no test files]
?   	github.com/autobrr/netronome/internal/handlers	[no test files]
?   	github.com/autobrr/netronome/internal/logger	[no test files]
ok  	github.com/autobrr/netronome/internal/monitor	(cached)
ok  	github.com/autobrr/netronome/internal/notifications	(cached)
ok  	github.com/autobrr/netronome/internal/scheduler	(cached)
ok  	github.com/autobrr/netronome/internal/server	0.518s
ok  	github.com/autobrr/netronome/internal/speedtest	(cached)
?   	github.com/autobrr/netronome/internal/tailscale	[no test files]
?   	github.com/autobrr/netronome/internal/types	[no test files]
ok  	github.com/autobrr/netronome/internal/utils	(cached)
?   	github.com/autobrr/netronome/internal/version	[no test files]
?   	github.com/autobrr/netronome/pkg/migrator	[no test files]
?   	github.com/autobrr/netronome/web	[no test files]
- ok  	github.com/autobrr/netronome/internal/database	(cached)
ok  	github.com/autobrr/netronome/internal/server	(cached)
- 
- 
> web@0.0.0 build /Users/soup/.codex/worktrees/57bc/netronome/web
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 5250 modules transformed.
rendering chunks...
computing gzip size...
dist/registerSW.js                                   0.14 kB
dist/manifest.webmanifest                            0.56 kB
dist/index.html                                      3.03 kB │ gzip:   1.21 kB
dist/assets/zze0s-gh0wHRA3.png                      12.04 kB
dist/assets/logo_small-BqRcpYEM.png                 32.56 kB
dist/assets/index-qUPCx3x2.css                     210.67 kB │ gzip:  58.73 kB
dist/assets/workbox-window.prod.es5-BIl4cyR9.js      5.82 kB │ gzip:   2.41 kB │ map:     13.68 kB
dist/assets/index-DzJ7GANE.js                    1,697.70 kB │ gzip: 492.05 kB │ map: 16,075.59 kB
✓ built in 4.35s

PWA v1.2.0
mode      generateSW
precache  5 entries (0.00 KiB)
files generated
  dist/sw.js.map
  dist/sw.js
  dist/workbox-7dfa5180.js.map
  dist/workbox-7dfa5180.js
- 
> web@0.0.0 lint /Users/soup/.codex/worktrees/57bc/netronome/web
> eslint .


/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/monitor/MonitorAgentForm.tsx
  50:7  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/monitor/MonitorAgentForm.tsx:50:7
  48 |   useEffect(() => {
  49 |     if (agent) {
> 50 |       setFormData({
     |       ^^^^^^^^^^^ Avoid calling setState() directly within an effect
  51 |         name: agent.name,
  52 |         url: agent.url.replace(/\/events\?stream=live-data$/, ""),
  53 |         apiKey: agent.apiKey || "",  react-hooks/set-state-in-effect

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/monitor/tabs/MonitorSystemTab.tsx
  151:94  error  Error: Cannot call impure function during render

`Date.now` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/monitor/tabs/MonitorSystemTab.tsx:151:94
  149 |         >
  150 |           {hardwareStats?.from_cache || systemInfo?.from_cache ? "Data collected" : "Last updated"}:{" "}
> 151 |           {formatters.time(new Date((hardwareStats?.updated_at || systemInfo?.updated_at) || Date.now()))}
      |                                                                                              ^^^^^^^^^^ Cannot call impure function
  152 |           {(hardwareStats?.from_cache || systemInfo?.from_cache) && " (cached)"}
  153 |         </motion.div>
  154 |       )}  react-hooks/purity

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/speedtest/DashboardTab.tsx
  107:43  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/speedtest/SpeedHistoryChart.tsx
  205:32  error    Compilation Skipped: Existing memoization could not be preserved

React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `timeRange`, but the source dependencies were [data]. Inferred different dependency than source.

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/speedtest/SpeedHistoryChart.tsx:205:32
  203 |     });
  204 |
> 205 |   const filteredData = useMemo(() => {
      |                                ^^^^^^^
> 206 |     if (!data) return [];
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 207 |
      …
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 235 |       );
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 236 |   }, [data]);
      | ^^^^ Could not preserve existing manual memoization
  237 |
  238 |   // Extract available servers from results
  239 |   const availableServers = useMemo(() => {  react-hooks/preserve-manual-memoization
  205:32  error    Compilation Skipped: Existing memoization could not be preserved

React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `timeRange`, but the source dependencies were [data]. Inferred different dependency than source.

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/speedtest/SpeedHistoryChart.tsx:205:32
  203 |     });
  204 |
> 205 |   const filteredData = useMemo(() => {
      |                                ^^^^^^^
> 206 |     if (!data) return [];
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 207 |
      …
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 235 |       );
      | ^^^^^^^^^^^^^^^^^^^^^^^^^
> 236 |   }, [data]);
      | ^^^^ Could not preserve existing manual memoization
  237 |
  238 |   // Extract available servers from results
  239 |   const availableServers = useMemo(() => {  react-hooks/preserve-manual-memoization
  236:6   warning  React Hook useMemo has a missing dependency: 'timeRange'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            react-hooks/exhaustive-deps
  269:6   warning  React Hook useMemo has an unnecessary dependency: 'availableServers'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                react-hooks/exhaustive-deps
  317:62  error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              @typescript-eslint/no-explicit-any
  528:44  error    Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              @typescript-eslint/no-explicit-any
  552:17  error    Compilation Skipped: Existing memoization could not be preserved

React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. This value was memoized in source but not in compilation output.

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/speedtest/SpeedHistoryChart.tsx:552:17
  550 |   };
  551 |
> 552 |   const chart = useMemo(
      |                 ^^^^^^^^
> 553 |     () => (
      | ^^^^^^^^^^^
> 554 |       <ResponsiveContainer width="100%" height="100%">
      …
      | ^^^^^^^^^^^
> 817 |     [allResults, timeRange, visibleMetrics, isMobile, isPublic, availableServers]
      | ^^^^^^^^^^^
> 818 |   );
      | ^^^^ Could not preserve existing memoization
  819 |
  820 |   const [isOpen, setIsOpen] = useState(() => {
  821 |     const saved = localStorage.getItem("speedtest-chart-open");                                                                                                                                                                       react-hooks/preserve-manual-memoization
  817:5   warning  React Hook useMemo has an unnecessary dependency: 'availableServers'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                react-hooks/exhaustive-deps

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/Button.tsx
  81:18  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/badge.tsx
  56:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/data-table.tsx
  113:17  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/data-table.tsx:113:17
  111 |   }, [columns, showRowSelection]);
  112 |
> 113 |   const table = useReactTable({
      |                 ^^^^^^^^^^^^^ TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely
  114 |     data,
  115 |     columns: tableColumns,
  116 |     onSortingChange: setSorting,  react-hooks/incompatible-library
  291:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      react-refresh/only-export-components
  311:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      react-refresh/only-export-components

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/sonner.tsx
  15:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

/Users/soup/.codex/worktrees/57bc/netronome/web/src/components/ui/sonner.tsx:15:5
  13 |     // Check initial theme
  14 |     const isDark = document.documentElement.classList.contains("dark");
> 15 |     setTheme(isDark ? "dark" : "light");
     |     ^^^^^^^^ Avoid calling setState() directly within an effect
  16 |
  17 |     // Watch for theme changes
  18 |     const observer = new MutationObserver((mutations) => {  react-hooks/set-state-in-effect

/Users/soup/.codex/worktrees/57bc/netronome/web/src/context/auth.tsx
  110:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/soup/.codex/worktrees/57bc/netronome/web/src/routes.tsx
  20:10  warning  Fast refresh only works when a file only exports components. Move your component(s) to a separate file. If all exports are HOCs, add them to the `extraHOCs` option  react-refresh/only-export-components
  46:10  warning  Fast refresh only works when a file only exports components. Move your component(s) to a separate file. If all exports are HOCs, add them to the `extraHOCs` option  react-refresh/only-export-components

/Users/soup/.codex/worktrees/57bc/netronome/web/src/utils/agentIcons.tsx
  156:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

✖ 21 problems (9 errors, 12 warnings)

 ELIFECYCLE  Command failed with exit code 1. *(fails on pre-existing repo lint issues unrelated to this PR)*

Fixes #199