### PR TITLE
fix(oidc): retry provider init and decouple status from provider state

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -135,6 +135,11 @@ func (c *OIDCConfig) decryptJWE(jweToken string) (string, error) {
 	return string(decrypted), nil
 }
 
+const (
+	oidcInitMaxAttempts = 10
+	oidcInitRetryDelay  = 5 * time.Second
+)
+
 func NewOIDC(ctx context.Context, cfg config.OIDCConfig) (*OIDCConfig, error) {
 	if cfg.Issuer == "" {
 		log.Debug().Msg("Using built-in authentication")
@@ -143,17 +148,39 @@ func NewOIDC(ctx context.Context, cfg config.OIDCConfig) (*OIDCConfig, error) {
 
 	log.Debug().Str("issuer", cfg.Issuer).Msg("Initializing OIDC provider")
 
-	// Perform manual discovery
-	endpoints, _, err := getProviderEndpoints(ctx, http.DefaultClient, cfg.Issuer)
-	if err != nil {
-		log.Error().Err(err).Str("issuer", cfg.Issuer).Msg("Failed to discover OIDC provider endpoints")
-		return nil, fmt.Errorf("failed to discover OIDC provider endpoints: %w", err)
+	var (
+		endpoints oauth2.Endpoint
+		provider  *oidc.Provider
+		lastErr   error
+	)
+
+	for attempt := 1; attempt <= oidcInitMaxAttempts; attempt++ {
+		endpoints, _, lastErr = getProviderEndpoints(ctx, http.DefaultClient, cfg.Issuer)
+		if lastErr != nil {
+			log.Warn().Err(lastErr).Int("attempt", attempt).Int("max", oidcInitMaxAttempts).
+				Str("issuer", cfg.Issuer).Msg("Failed to discover OIDC provider endpoints")
+			if attempt < oidcInitMaxAttempts {
+				time.Sleep(oidcInitRetryDelay)
+			}
+			continue
+		}
+
+		provider, lastErr = oidc.NewProvider(ctx, cfg.Issuer)
+		if lastErr != nil {
+			log.Warn().Err(lastErr).Int("attempt", attempt).Int("max", oidcInitMaxAttempts).
+				Str("issuer", cfg.Issuer).Msg("Failed to initialize OIDC provider")
+			if attempt < oidcInitMaxAttempts {
+				time.Sleep(oidcInitRetryDelay)
+			}
+			continue
+		}
+
+		break
 	}
 
-	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
-	if err != nil {
-		log.Error().Err(err).Str("issuer", cfg.Issuer).Msg("Failed to initialize OIDC provider")
-		return nil, fmt.Errorf("failed to initialize OIDC provider: %w", err)
+	if lastErr != nil {
+		log.Error().Err(lastErr).Str("issuer", cfg.Issuer).Msg("Failed to initialize OIDC provider after all attempts")
+		return nil, fmt.Errorf("failed to initialize OIDC provider after %d attempts: %w", oidcInitMaxAttempts, lastErr)
 	}
 
 	scopes := cfg.Scopes

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -55,7 +55,7 @@ func (h *AuthHandler) CheckRegistrationStatus(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"hasUsers":    count > 0,
-		"oidcEnabled": h.oidc != nil,
+		"oidcEnabled": h.oidcConfigured,
 	})
 }
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -23,7 +23,7 @@ import (
 type AuthHandler struct {
 	db             database.Service
 	oidc           *auth.OIDCConfig
-	oidcConfigured bool // true when OIDC issuer is set in config, independent of provider state
+	oidcConfigured bool                     // true when OIDC issuer is set in config, independent of provider state
 	sessionTokens  map[string]SessionClaims // Track valid memory sessions
 	pkceVerifiers  map[string]string        // Track PKCE code verifiers by state
 	sessionMutex   sync.RWMutex
@@ -55,7 +55,7 @@ func (h *AuthHandler) CheckRegistrationStatus(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"hasUsers":    count > 0,
-		"oidcEnabled": h.oidcConfigured,
+		"oidcEnabled": h.oidc != nil,
 	})
 }
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -54,8 +54,9 @@ func (h *AuthHandler) CheckRegistrationStatus(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"hasUsers":    count > 0,
-		"oidcEnabled": h.oidcConfigured,
+		"hasUsers":       count > 0,
+		"oidcConfigured": h.oidcConfigured,
+		"oidcReady":      h.oidc != nil,
 	})
 }
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -21,24 +21,26 @@ import (
 )
 
 type AuthHandler struct {
-	db            database.Service
-	oidc          *auth.OIDCConfig
-	sessionTokens map[string]SessionClaims // Track valid memory sessions
-	pkceVerifiers map[string]string        // Track PKCE code verifiers by state
-	sessionMutex  sync.RWMutex
-	pkceMutex     sync.RWMutex
-	sessionSecret string
-	whitelist     []string
+	db             database.Service
+	oidc           *auth.OIDCConfig
+	oidcConfigured bool // true when OIDC issuer is set in config, independent of provider state
+	sessionTokens  map[string]SessionClaims // Track valid memory sessions
+	pkceVerifiers  map[string]string        // Track PKCE code verifiers by state
+	sessionMutex   sync.RWMutex
+	pkceMutex      sync.RWMutex
+	sessionSecret  string
+	whitelist      []string
 }
 
-func NewAuthHandler(db database.Service, oidc *auth.OIDCConfig, sessionSecret string, whitelist []string) *AuthHandler {
+func NewAuthHandler(db database.Service, oidc *auth.OIDCConfig, oidcConfigured bool, sessionSecret string, whitelist []string) *AuthHandler {
 	return &AuthHandler{
-		db:            db,
-		oidc:          oidc,
-		sessionTokens: make(map[string]SessionClaims),
-		pkceVerifiers: make(map[string]string),
-		sessionSecret: sessionSecret,
-		whitelist:     whitelist,
+		db:             db,
+		oidc:           oidc,
+		oidcConfigured: oidcConfigured,
+		sessionTokens:  make(map[string]SessionClaims),
+		pkceVerifiers:  make(map[string]string),
+		sessionSecret:  sessionSecret,
+		whitelist:      whitelist,
 	}
 }
 
@@ -53,7 +55,7 @@ func (h *AuthHandler) CheckRegistrationStatus(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"hasUsers":    count > 0,
-		"oidcEnabled": h.oidc != nil,
+		"oidcEnabled": h.oidcConfigured,
 	})
 }
 

--- a/internal/server/auth_oidc.go
+++ b/internal/server/auth_oidc.go
@@ -29,7 +29,7 @@ func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	state, err := utils.GenerateSecureToken(32)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate state parameter")
-		c.Redirect(http.StatusTemporaryRedirect, "/?error=state_generation_failed")
+		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=state_generation_failed")
 		return
 	}
 
@@ -37,7 +37,7 @@ func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	pkceParams, err := auth.GeneratePKCEParams()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate PKCE parameters")
-		c.Redirect(http.StatusTemporaryRedirect, "/?error=pkce_generation_failed")
+		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=pkce_generation_failed")
 		return
 	}
 

--- a/internal/server/auth_oidc.go
+++ b/internal/server/auth_oidc.go
@@ -17,10 +17,6 @@ import (
 
 func loginErrorRedirectURL(baseURL, errorCode string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
-	if baseURL == "" {
-		baseURL = ""
-	}
-
 	return baseURL + "/login?error=" + url.QueryEscape(errorCode)
 }
 

--- a/internal/server/auth_oidc.go
+++ b/internal/server/auth_oidc.go
@@ -13,16 +13,18 @@ import (
 	"github.com/autobrr/netronome/internal/utils"
 )
 
-func (h *AuthHandler) InitOIDCRoutes(r *gin.RouterGroup) {
+func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
+	baseURL := c.GetString("base_url")
+	if baseURL == "" {
+		baseURL = "/"
+	}
+
 	if h.oidc == nil {
+		log.Warn().Msg("OIDC login attempted but provider is not ready")
+		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=oidc_unavailable")
 		return
 	}
 
-	r.GET("/oidc/login", h.handleOIDCLogin)
-	r.GET("/oidc/callback", h.handleOIDCCallback)
-}
-
-func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	// Generate state parameter
 	state, err := utils.GenerateSecureToken(32)
 	if err != nil {
@@ -57,6 +59,12 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 	baseURL := c.GetString("base_url")
 	if baseURL == "" {
 		baseURL = "/"
+	}
+
+	if h.oidc == nil {
+		log.Warn().Msg("OIDC callback received but provider is not ready")
+		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=oidc_unavailable")
+		return
 	}
 
 	code := c.Query("code")

--- a/internal/server/auth_oidc.go
+++ b/internal/server/auth_oidc.go
@@ -5,6 +5,8 @@ package server
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -12,6 +14,15 @@ import (
 	"github.com/autobrr/netronome/internal/auth"
 	"github.com/autobrr/netronome/internal/utils"
 )
+
+func loginErrorRedirectURL(baseURL, errorCode string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" {
+		baseURL = ""
+	}
+
+	return baseURL + "/login?error=" + url.QueryEscape(errorCode)
+}
 
 func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	baseURL := c.GetString("base_url")
@@ -21,7 +32,7 @@ func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 
 	if h.oidc == nil {
 		log.Warn().Msg("OIDC login attempted but provider is not ready")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=oidc_unavailable")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "oidc_unavailable"))
 		return
 	}
 
@@ -29,7 +40,7 @@ func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	state, err := utils.GenerateSecureToken(32)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate state parameter")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=state_generation_failed")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "state_generation_failed"))
 		return
 	}
 
@@ -37,7 +48,7 @@ func (h *AuthHandler) handleOIDCLogin(c *gin.Context) {
 	pkceParams, err := auth.GeneratePKCEParams()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate PKCE parameters")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=pkce_generation_failed")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "pkce_generation_failed"))
 		return
 	}
 
@@ -63,21 +74,21 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 
 	if h.oidc == nil {
 		log.Warn().Msg("OIDC callback received but provider is not ready")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=oidc_unavailable")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "oidc_unavailable"))
 		return
 	}
 
 	code := c.Query("code")
 	if code == "" {
 		log.Error().Msg("no code received in callback")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=invalid_code")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "invalid_code"))
 		return
 	}
 
 	state := c.Query("state")
 	if state == "" {
 		log.Error().Msg("no state received in callback")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=invalid_state")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "invalid_state"))
 		return
 	}
 
@@ -86,7 +97,7 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 	codeVerifier, exists := h.getPKCEVerifier(state)
 	if !exists {
 		log.Error().Str("state", state).Msg("no PKCE verifier found for state")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=invalid_state")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "invalid_state"))
 		return
 	}
 
@@ -94,7 +105,7 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 	token, err := h.oidc.ExchangeCodeWithPKCE(c.Request.Context(), code, codeVerifier)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to exchange code for token with PKCE")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=token_exchange")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "token_exchange"))
 		return
 	}
 
@@ -106,7 +117,7 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
 		log.Error().Msg("no id_token in oauth2 token")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=missing_id_token")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "missing_id_token"))
 		return
 	}
 
@@ -114,7 +125,7 @@ func (h *AuthHandler) handleOIDCCallback(c *gin.Context) {
 	idClaims, err := h.oidc.VerifyTokenWithClaims(c.Request.Context(), rawIDToken)
 	if err != nil {
 		log.Error().Err(err).Msg("invalid ID token")
-		c.Redirect(http.StatusTemporaryRedirect, baseURL+"login?error=invalid_token")
+		c.Redirect(http.StatusTemporaryRedirect, loginErrorRedirectURL(baseURL, "invalid_token"))
 		return
 	}
 

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -102,32 +102,36 @@ func newAuthStatusTestDB(t *testing.T) database.Service {
 	}
 }
 
-func TestCheckRegistrationStatusReportsOIDCProviderReadiness(t *testing.T) {
+func TestCheckRegistrationStatusReportsOIDCState(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name           string
-		oidc           *auth.OIDCConfig
-		oidcConfigured bool
-		expectedOID    bool
+		name                   string
+		oidc                   *auth.OIDCConfig
+		oidcConfigured         bool
+		expectedOIDCConfigured bool
+		expectedOIDCReady      bool
 	}{
 		{
-			name:           "configured but provider unavailable",
-			oidc:           nil,
-			oidcConfigured: true,
-			expectedOID:    true,
+			name:                   "configured but provider unavailable",
+			oidc:                   nil,
+			oidcConfigured:         true,
+			expectedOIDCConfigured: true,
+			expectedOIDCReady:      false,
 		},
 		{
-			name:           "configured and provider ready",
-			oidc:           &auth.OIDCConfig{},
-			oidcConfigured: true,
-			expectedOID:    true,
+			name:                   "configured and provider ready",
+			oidc:                   &auth.OIDCConfig{},
+			oidcConfigured:         true,
+			expectedOIDCConfigured: true,
+			expectedOIDCReady:      true,
 		},
 		{
-			name:           "not configured and provider unavailable",
-			oidc:           nil,
-			oidcConfigured: false,
-			expectedOID:    false,
+			name:                   "not configured and provider unavailable",
+			oidc:                   nil,
+			oidcConfigured:         false,
+			expectedOIDCConfigured: false,
+			expectedOIDCReady:      false,
 		},
 	}
 
@@ -144,12 +148,14 @@ func TestCheckRegistrationStatusReportsOIDCProviderReadiness(t *testing.T) {
 			require.Equal(t, http.StatusOK, recorder.Code)
 
 			var response struct {
-				HasUsers    bool `json:"hasUsers"`
-				OIDCEnabled bool `json:"oidcEnabled"`
+				HasUsers       bool `json:"hasUsers"`
+				OIDCConfigured bool `json:"oidcConfigured"`
+				OIDCReady      bool `json:"oidcReady"`
 			}
 			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 			assert.False(t, response.HasUsers)
-			assert.Equal(t, tt.expectedOID, response.OIDCEnabled)
+			assert.Equal(t, tt.expectedOIDCConfigured, response.OIDCConfigured)
+			assert.Equal(t, tt.expectedOIDCReady, response.OIDCReady)
 		})
 	}
 }

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -106,25 +106,34 @@ func TestCheckRegistrationStatusReportsOIDCProviderReadiness(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name        string
-		oidc        *auth.OIDCConfig
-		expectedOID bool
+		name           string
+		oidc           *auth.OIDCConfig
+		oidcConfigured bool
+		expectedOID    bool
 	}{
 		{
-			name:        "configured but provider unavailable",
-			oidc:        nil,
-			expectedOID: false,
+			name:           "configured but provider unavailable",
+			oidc:           nil,
+			oidcConfigured: true,
+			expectedOID:    true,
 		},
 		{
-			name:        "configured and provider ready",
-			oidc:        &auth.OIDCConfig{},
-			expectedOID: true,
+			name:           "configured and provider ready",
+			oidc:           &auth.OIDCConfig{},
+			oidcConfigured: true,
+			expectedOID:    true,
+		},
+		{
+			name:           "not configured and provider unavailable",
+			oidc:           nil,
+			oidcConfigured: false,
+			expectedOID:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := NewAuthHandler(newAuthStatusTestDB(t), tt.oidc, true, "", nil)
+			handler := NewAuthHandler(newAuthStatusTestDB(t), tt.oidc, tt.oidcConfigured, "", nil)
 
 			recorder := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(recorder)

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -4,12 +4,20 @@
 package server
 
 import (
+	"context"
+	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"github.com/autobrr/netronome/internal/auth"
+	"github.com/autobrr/netronome/internal/database"
 )
 
 func TestIsWhitelisted(t *testing.T) {
@@ -63,4 +71,108 @@ func TestIsWhitelisted(t *testing.T) {
 			assert.Equal(t, tt.expected, got, "isWhitelisted() result mismatch")
 		})
 	}
+}
+
+type stubDB struct {
+	database.Service
+	queryRow func(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+func (s stubDB) QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return s.queryRow(ctx, query, args...)
+}
+
+func newAuthStatusTestDB(t *testing.T) database.Service {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	_, err = db.Exec("CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+
+	return stubDB{
+		queryRow: func(ctx context.Context, query string, args ...interface{}) *sql.Row {
+			return db.QueryRowContext(ctx, query, args...)
+		},
+	}
+}
+
+func TestCheckRegistrationStatusReportsOIDCProviderReadiness(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		oidc        *auth.OIDCConfig
+		expectedOID bool
+	}{
+		{
+			name:        "configured but provider unavailable",
+			oidc:        nil,
+			expectedOID: false,
+		},
+		{
+			name:        "configured and provider ready",
+			oidc:        &auth.OIDCConfig{},
+			expectedOID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewAuthHandler(newAuthStatusTestDB(t), tt.oidc, true, "", nil)
+
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodGet, "/api/auth/status", nil)
+
+			handler.CheckRegistrationStatus(c)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			var response struct {
+				HasUsers    bool `json:"hasUsers"`
+				OIDCEnabled bool `json:"oidcEnabled"`
+			}
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.False(t, response.HasUsers)
+			assert.Equal(t, tt.expectedOID, response.OIDCEnabled)
+		})
+	}
+}
+
+func TestHandleOIDCLoginRedirectUsesLoginPathUnderSubpathBaseURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewAuthHandler(nil, nil, true, "", nil)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil)
+	c.Set("base_url", "/netronome")
+
+	handler.handleOIDCLogin(c)
+
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	assert.Equal(t, "/netronome/login?error=oidc_unavailable", recorder.Header().Get("Location"))
+}
+
+func TestHandleOIDCCallbackRedirectUsesLoginPathUnderSubpathBaseURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewAuthHandler(nil, nil, true, "", nil)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback", nil)
+	c.Set("base_url", "/netronome")
+
+	handler.handleOIDCCallback(c)
+
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	assert.Equal(t, "/netronome/login?error=oidc_unavailable", recorder.Header().Get("Location"))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,7 +88,7 @@ func NewServer(speedtest speedtest.Service, db database.Service, scheduler sched
 		monitorService:    monitorService,
 		db:                db,
 		scheduler:         scheduler,
-		auth:              NewAuthHandler(db, oidcConfig, cfg.Session.Secret, cfg.Auth.Whitelist),
+		auth:              NewAuthHandler(db, oidcConfig, cfg.OIDC.Issuer != "", cfg.Session.Secret, cfg.Auth.Whitelist),
 		notifier:          notifier,
 		lastUpdate:        &types.SpeedUpdate{},
 		config:            cfg,
@@ -212,7 +212,7 @@ func (s *Server) RegisterRoutes() {
 			auth.GET("/status", s.auth.CheckRegistrationStatus)
 			auth.POST("/register", s.auth.Register)
 			auth.POST("/login", s.auth.Login)
-			if s.auth.oidc != nil {
+			if s.auth.oidcConfigured {
 				auth.GET("/oidc/login", s.auth.handleOIDCLogin)
 				auth.GET("/oidc/callback", s.auth.handleOIDCCallback)
 			}

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -22,7 +22,6 @@ interface UserResponse {
 }
 
 interface RegistrationStatus {
-  registrationEnabled: boolean;
   hasUsers: boolean;
   oidcConfigured: boolean;
   oidcReady: boolean;
@@ -146,7 +145,6 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
     if (response.ok) {
       const data = await response.json();
       return {
-        registrationEnabled: data.registrationEnabled ?? false,
         hasUsers: data.hasUsers ?? true,
         oidcConfigured: data.oidcConfigured ?? false,
         oidcReady: data.oidcReady ?? false,
@@ -155,7 +153,6 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
 
     // If the endpoint fails, assume users exist to prevent unwanted registration
     return {
-      registrationEnabled: false,
       hasUsers: true,
       oidcConfigured: false,
       oidcReady: false,
@@ -164,7 +161,6 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
     console.error("Registration status check failed:", error);
     // Default to secure state
     return {
-      registrationEnabled: false,
       hasUsers: true,
       oidcConfigured: false,
       oidcReady: false,

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -24,7 +24,8 @@ interface UserResponse {
 interface RegistrationStatus {
   registrationEnabled: boolean;
   hasUsers: boolean;
-  oidcEnabled: boolean;
+  oidcConfigured: boolean;
+  oidcReady: boolean;
 }
 
 export async function login(
@@ -147,7 +148,8 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
       return {
         registrationEnabled: data.registrationEnabled ?? false,
         hasUsers: data.hasUsers ?? true,
-        oidcEnabled: data.oidcEnabled ?? false,
+        oidcConfigured: data.oidcConfigured ?? false,
+        oidcReady: data.oidcReady ?? false,
       };
     }
 
@@ -155,7 +157,8 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
     return {
       registrationEnabled: false,
       hasUsers: true,
-      oidcEnabled: false,
+      oidcConfigured: false,
+      oidcReady: false,
     };
   } catch (error) {
     console.error("Registration status check failed:", error);
@@ -163,7 +166,8 @@ export async function checkRegistrationStatus(): Promise<RegistrationStatus> {
     return {
       registrationEnabled: false,
       hasUsers: true,
-      oidcEnabled: false,
+      oidcConfigured: false,
+      oidcReady: false,
     };
   }
 }

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -25,35 +25,53 @@ const ERROR_MESSAGES: Record<string, string> = {
   "Failed to generate session token": "Authentication failed, please try again",
 };
 
+const OIDC_ERROR_MESSAGES: Record<string, string> = {
+  oidc_unavailable: "OpenID Connect sign-in is currently unavailable. Use local credentials if you have them.",
+};
+
+function getInitialLoginError(): string {
+  const errorCode = new URLSearchParams(window.location.search).get("error");
+  if (!errorCode) {
+    return "";
+  }
+
+  return OIDC_ERROR_MESSAGES[errorCode] || "Unable to sign in with OpenID Connect.";
+}
+
 export default function Login() {
   const { login, checkRegistrationStatus } = useAuth();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const [error, setError] = useState(getInitialLoginError);
   const [isLoading, setIsLoading] = useState(true);
-  const [oidcEnabled, setOidcEnabled] = useState(false);
+  const [authOptions, setAuthOptions] = useState({
+    hasUsers: true,
+    oidcConfigured: false,
+    oidcReady: false,
+  });
 
   useEffect(() => {
     const checkStatus = async () => {
       try {
         const status = await checkRegistrationStatus();
-        setOidcEnabled(status.oidcEnabled);
+        setAuthOptions({
+          hasUsers: status.hasUsers,
+          oidcConfigured: status.oidcConfigured,
+          oidcReady: status.oidcReady,
+        });
 
-        if (!status.hasUsers && !status.oidcEnabled) {
+        if (!status.hasUsers && !status.oidcConfigured) {
           await router.navigate({ to: "/register" });
         }
       } catch (err) {
         console.error("Failed to check registration status:", err);
-        if (!oidcEnabled) {
-          await router.navigate({ to: "/register" });
-        }
       } finally {
         setIsLoading(false);
       }
     };
 
     checkStatus();
-  }, [checkRegistrationStatus, oidcEnabled]);
+  }, [checkRegistrationStatus]);
 
   const handleOIDCLogin = () => {
     window.location.href = getApiUrl("/auth/oidc/login");
@@ -68,13 +86,13 @@ export default function Login() {
     } catch (err) {
       if (err instanceof Error) {
         const errorMessage = err.message;
-        
+
         if (errorMessage.includes("User not found")) {
           console.log("No users found during login, redirecting...");
           router.navigate({ to: "/register" });
           return;
         }
-        
+
         setError(ERROR_MESSAGES[errorMessage] || "An error occurred while signing in");
       } else {
         setError("Unable to sign in at this time");
@@ -108,72 +126,93 @@ export default function Login() {
         </CardHeader>
 
         <CardContent className="pt-6">
-          {oidcEnabled ? (
-            <Button
-              onClick={handleOIDCLogin}
-              variant="outline"
-              className="w-full border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400"
-              size="lg"
-            >
-              <span className="flex items-center" aria-label="Sign in with OpenID">
-                Sign in with
-                <FontAwesomeIcon icon={faOpenid} className="text-lg ml-2" aria-hidden="true" />
-              </span>
-            </Button>
-          ) : (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              {error && (
-                <div className="bg-red-100 dark:bg-red-900/20 border border-red-400 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-md text-sm">
-                  {error}
-                </div>
-              )}
+          <div className="space-y-4">
+            {error && (
+              <div className="bg-red-100 dark:bg-red-900/20 border border-red-400 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-md text-sm">
+                {error}
+              </div>
+            )}
 
-              <div className="space-y-4">
-                <div>
-                  <Label htmlFor="username" className="sr-only">
-                    Username
-                  </Label>
-                  <Input
-                    id="username"
-                    name="username"
-                    type="text"
-                    autoComplete="username"
-                    required
-                    placeholder="Username"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    className={cn(
-                      "dark:bg-gray-800 dark:border-gray-700",
-                      error && "border-red-500 dark:border-red-500"
-                    )}
-                  />
+            {authOptions.oidcReady && (
+              <Button
+                onClick={handleOIDCLogin}
+                variant="outline"
+                className="w-full border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400"
+                size="lg"
+              >
+                <span className="flex items-center" aria-label="Sign in with OpenID">
+                  Sign in with
+                  <FontAwesomeIcon icon={faOpenid} className="text-lg ml-2" aria-hidden="true" />
+                </span>
+              </Button>
+            )}
+
+            {authOptions.oidcReady && authOptions.hasUsers && (
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center" aria-hidden="true">
+                  <div className="w-full border-t border-gray-200 dark:border-gray-700" />
                 </div>
-                <div>
-                  <Label htmlFor="password" className="sr-only">
-                    Password
-                  </Label>
-                  <Input
-                    id="password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    required
-                    placeholder="Password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className={cn(
-                      "dark:bg-gray-800 dark:border-gray-700",
-                      error && "border-red-500 dark:border-red-500"
-                    )}
-                  />
+                <div className="relative flex justify-center text-xs uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400">
+                  <span className="bg-white dark:bg-gray-850 px-3">or</span>
                 </div>
               </div>
+            )}
 
-              <Button type="submit" className="w-full" size="lg">
-                Sign in
-              </Button>
-            </form>
-          )}
+            {authOptions.hasUsers && (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="username" className="sr-only">
+                      Username
+                    </Label>
+                    <Input
+                      id="username"
+                      name="username"
+                      type="text"
+                      autoComplete="username"
+                      required
+                      placeholder="Username"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      className={cn(
+                        "dark:bg-gray-800 dark:border-gray-700",
+                        error && "border-red-500 dark:border-red-500"
+                      )}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="password" className="sr-only">
+                      Password
+                    </Label>
+                    <Input
+                      id="password"
+                      name="password"
+                      type="password"
+                      autoComplete="current-password"
+                      required
+                      placeholder="Password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className={cn(
+                        "dark:bg-gray-800 dark:border-gray-700",
+                        error && "border-red-500 dark:border-red-500"
+                      )}
+                    />
+                  </div>
+                </div>
+
+                <Button type="submit" className="w-full" size="lg">
+                  Sign in
+                </Button>
+              </form>
+            )}
+
+            {!authOptions.hasUsers && authOptions.oidcConfigured && !authOptions.oidcReady && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+                OpenID Connect is configured but the provider is unavailable right now.
+              </div>
+            )}
+          </div>
           <Footer />
         </CardContent>
       </Card>

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -19,7 +19,6 @@ interface AuthContextType {
   register: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   checkRegistrationStatus: () => Promise<{
-    registrationEnabled: boolean;
     hasUsers: boolean;
     oidcConfigured: boolean;
     oidcReady: boolean;

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -21,7 +21,8 @@ interface AuthContextType {
   checkRegistrationStatus: () => Promise<{
     registrationEnabled: boolean;
     hasUsers: boolean;
-    oidcEnabled: boolean;
+    oidcConfigured: boolean;
+    oidcReady: boolean;
   }>;
 }
 
@@ -34,7 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     // Skip auth check if we're on the public route
     const isPublicRoute = window.location.pathname.includes('/public');
-    
+
     if (isPublicRoute) {
       setIsLoading(false);
       return;

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -73,7 +73,7 @@ function AuthRoute() {
         const status = await checkRegistrationStatus();
         console.log("AuthRoute: Status received:", status);
 
-        if (!status.hasUsers && !status.oidcEnabled) {
+        if (!status.hasUsers && !status.oidcConfigured) {
           console.log("AuthRoute: No users found and OIDC not enabled, redirecting...");
           navigate({ to: "/register" });
         }


### PR DESCRIPTION
OIDC silently disables itself when the container restarts while the identity provider is temporarily unreachable — `NewOIDC` fails once and the server continues with `h.oidc = nil`, causing `/api/auth/status` to report `oidcEnabled: false` permanently until manual restart. This adds a retry loop (10 attempts, 5s intervals) to OIDC provider initialization and decouples the `oidcEnabled` response from runtime provider state by tracking whether OIDC was configured, matching autobrr's approach.

OIDC routes are now registered whenever an issuer is configured rather than only when the provider initialized successfully, with nil guards in the handlers returning a graceful `oidc_unavailable` redirect if the provider isn't ready.

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry/backoff for OIDC provider initialization to improve resilience.

* **Bug Fixes**
  * OIDC endpoints and status now reflect issuer configuration; API reports separate oidcConfigured and oidcReady flags.
  * Improved OIDC-unavailable handling with early redirects, consistent redirect URLs, and clearer logging on initialization failures.

* **Tests**
  * Added tests for OIDC readiness reporting and redirect behavior under subpath base URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->