### PR TITLE
fix: slim packet loss history payloads

### DIFF
--- a/docs/superpowers/plans/2026-04-09-packetloss-history-cutover.md
+++ b/docs/superpowers/plans/2026-04-09-packetloss-history-cutover.md
@@ -1,0 +1,147 @@
+# Packet Loss History Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the current expandable MTR UI, but remove `mtrData` from the normal packet-loss history list so large MTR blobs no longer inflate history requests or server memory.
+
+**Architecture:** Split packet-loss history into two shapes. The existing history endpoint becomes a paginated summary feed with no `mtrData`. A new detail endpoint returns a single result, including `mtrData`, only when a user expands an MTR row. Add a composite index so summary history queries stop building temp sort state for common monitor history reads.
+
+**Tech Stack:** Go, Gin, SQLite/Postgres SQL via squirrel, React, TanStack Query, TypeScript
+
+---
+
+## File Map
+
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/types/types.go`
+  Summary packet-loss history type and detail type split.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/database.go`
+  Database service interface additions for summary/detail history reads.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/packetloss.go`
+  Summary query without `mtr_data`, single-result detail query with `mtr_data`.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/handlers/packetloss.go`
+  Paginated summary history endpoint and new detail endpoint.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/server/server.go`
+  Route registration for new detail endpoint.
+- Add: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/migrations/sqlite/021_packetloss_history_summary_index.sql`
+  Composite index for packet-loss history ordering.
+- Add: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/migrations/postgres/021_packetloss_history_summary_index_postgres.sql`
+  Postgres equivalent index.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/packetloss_integration_test.go`
+  Database coverage for summary rows and detail fetch.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/types/types.ts`
+  Split summary history row from full detail row.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/api/packetloss.ts`
+  Paginated summary fetch and detail fetch.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx`
+  Summary history query wiring.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts`
+  Refetch summary history only.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx`
+  Lazy detail fetch per expanded row and pagination controls.
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/components/MTRResultsDisplay.tsx`
+  Keep rendering contract aligned with lazy-loaded detail data.
+
+### Task 1: Backend Summary/Detail Split
+
+**Files:**
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/types/types.go`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/database.go`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/packetloss.go`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/handlers/packetloss.go`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/server/server.go`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/packetloss_integration_test.go`
+
+- [ ] Add failing integration coverage for:
+  - summary history returns rows without `mtr_data`
+  - detail fetch returns `mtr_data` for one result
+  - history endpoint pagination metadata is correct
+
+- [ ] Introduce dedicated summary/detail result types in Go so the history list is not forced to carry the blob field.
+
+- [ ] Replace `GetPacketLossResults(monitorID, limit)` with:
+  - paginated summary read ordered by newest first
+  - single-result detail read by result id + monitor id
+
+- [ ] Update the handler layer:
+  - existing `/packetloss/monitors/:id/history` becomes paginated summary-only
+  - add `/packetloss/monitors/:id/history/:resultId` for full detail
+
+- [ ] Update route registration and keep existing clients working only through the new response shape used by this branch.
+
+- [ ] Run focused backend tests for packet-loss database/handler behavior.
+
+### Task 2: Query/Index Hardening
+
+**Files:**
+- Add: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/migrations/sqlite/021_packetloss_history_summary_index.sql`
+- Add: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/migrations/postgres/021_packetloss_history_summary_index_postgres.sql`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/internal/database/packetloss_integration_test.go`
+
+- [ ] Add a composite history index on `(monitor_id, created_at DESC)` for both SQLite and Postgres.
+
+- [ ] Extend integration coverage so history reads still return newest-first rows after migrations.
+
+- [ ] Run focused migration/integration tests for packet-loss database access.
+
+### Task 3: Frontend Summary History + Lazy MTR Detail
+
+**Files:**
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/types/types.ts`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/api/packetloss.ts`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx`
+- Modify: `/Users/soup/.codex/worktrees/4fd8/netronome/web/src/components/speedtest/packetloss/components/MTRResultsDisplay.tsx`
+
+- [ ] Split packet-loss summary row typing from packet-loss detail typing in TypeScript.
+
+- [ ] Change the default history request to fetch paginated summary rows only.
+
+- [ ] Keep the current expandable MTR interaction, but lazy-load full detail when a row is expanded instead of parsing `mtrData` from the summary list.
+
+- [ ] Preserve current summary UX:
+  - timestamps
+  - RTT metrics
+  - sent/recv
+  - mode badge
+  - hop count
+
+- [ ] Add simple page/load-more behavior on top of the paginated summary response instead of relying on one large result payload.
+
+- [ ] Run frontend lint after the TypeScript/API changes.
+
+### Task 4: Verification And Review Gate
+
+**Files:**
+- Review only
+
+- [ ] Run focused backend tests covering packet-loss history and migrations.
+
+- [ ] Run `pnpm -C web lint`.
+
+- [ ] Run one end-to-end manual smoke check:
+  - open packet-loss history
+  - confirm summary list renders without raw `mtrData`
+  - expand an MTR row
+  - confirm the hop-by-hop UI still renders from the new detail endpoint
+
+- [ ] Dispatch two parallel review subagents:
+  - Reviewer A: `gpt-5.4` with `high` reasoning, focused on backend/API/query correctness
+  - Reviewer B: `gpt-5.4` with `high` reasoning, focused on frontend behavior/regression risk
+
+- [ ] Resolve reviewer findings before final handoff.
+
+## Self-Review
+
+- Spec coverage:
+  - preserve current MTR UI behavior: covered in Task 3
+  - hard cutover away from blob-heavy history list: covered in Task 1
+  - reduce query memory pressure: covered in Task 2
+  - review against plan with two subagents: covered in Task 4
+
+- Placeholder scan:
+  - no `TODO`/`TBD`
+  - every task maps to concrete files and outcomes
+
+- Type consistency:
+  - plan uses `summary` vs `detail` terminology consistently across backend and frontend

--- a/internal/database/cascade_delete_integration_test.go
+++ b/internal/database/cascade_delete_integration_test.go
@@ -49,9 +49,9 @@ func TestPacketLossMonitor_CascadeDelete(t *testing.T) {
 		}
 
 		// Verify we can retrieve results for the monitor
-		results, err := td.Service.GetPacketLossResults(monitor.ID, 10)
+		results, err := td.Service.GetPacketLossResults(monitor.ID, 1, 10)
 		require.NoError(t, err)
-		assert.Len(t, results, 5)
+		assert.Len(t, results.Data, 5)
 
 		// Delete the monitor
 		err = td.Service.DeletePacketLossMonitor(monitor.ID)
@@ -66,9 +66,9 @@ func TestPacketLossMonitor_CascadeDelete(t *testing.T) {
 		}
 
 		// Double-check by trying to retrieve results
-		results, err = td.Service.GetPacketLossResults(monitor.ID, 10)
+		results, err = td.Service.GetPacketLossResults(monitor.ID, 1, 10)
 		require.NoError(t, err)
-		assert.Empty(t, results)
+		assert.Empty(t, results.Data)
 	})
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -90,7 +90,8 @@ type Service interface {
 	UpdatePacketLossMonitor(monitor *types.PacketLossMonitor) error
 	DeletePacketLossMonitor(monitorID int64) error
 	GetPacketLossMonitors() ([]*types.PacketLossMonitor, error)
-	GetPacketLossResults(monitorID int64, limit int) ([]*types.PacketLossResult, error)
+	GetPacketLossResults(monitorID int64, page int, limit int) (*types.PaginatedPacketLossResults, error)
+	GetPacketLossResultDetail(monitorID int64, resultID int64) (*types.PacketLossResult, error)
 	UpdatePacketLossMonitorState(monitorID int64, state string) error
 
 	// Monitor operations

--- a/internal/database/migrations/postgres/021_packetloss_history_summary_index_postgres.sql
+++ b/internal/database/migrations/postgres/021_packetloss_history_summary_index_postgres.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_packet_loss_results_monitor_created_at
+ON packet_loss_results(monitor_id, created_at DESC, id DESC);

--- a/internal/database/migrations/sqlite/021_packetloss_history_summary_index.sql
+++ b/internal/database/migrations/sqlite/021_packetloss_history_summary_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_packet_loss_results_monitor_created_at
+ON packet_loss_results(monitor_id, created_at DESC, id DESC);

--- a/internal/database/packetloss.go
+++ b/internal/database/packetloss.go
@@ -323,27 +323,42 @@ func (s *service) GetPacketLossMonitors() ([]*types.PacketLossMonitor, error) {
 	return monitors, nil
 }
 
-// GetPacketLossResults retrieves packet loss results for a monitor
-func (s *service) GetPacketLossResults(monitorID int64, limit int) ([]*types.PacketLossResult, error) {
+// GetPacketLossResults retrieves paginated packet loss result summaries for a monitor.
+func (s *service) GetPacketLossResults(monitorID int64, page int, limit int) (*types.PaginatedPacketLossResults, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	countQuery := s.sqlBuilder.
+		Select("COUNT(*)").
+		From("packet_loss_results").
+		Where(sq.Eq{"monitor_id": monitorID})
+
+	var total int
+	if err := countQuery.RunWith(s.db).QueryRow().Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count packet loss results: %w", err)
+	}
+
 	query := s.sqlBuilder.
-		Select("id", "monitor_id", "packet_loss", "min_rtt", "max_rtt", "avg_rtt", "std_dev_rtt", "packets_sent", "packets_recv", "used_mtr", "hop_count", "mtr_data", "privileged_mode", "created_at").
+		Select("id", "monitor_id", "packet_loss", "min_rtt", "max_rtt", "avg_rtt", "std_dev_rtt", "packets_sent", "packets_recv", "used_mtr", "hop_count", "privileged_mode", "created_at").
 		From("packet_loss_results").
 		Where(sq.Eq{"monitor_id": monitorID}).
-		OrderBy("created_at DESC")
-
-	if limit > 0 {
-		query = query.Limit(uint64(limit))
-	}
+		OrderBy("created_at DESC", "id DESC").
+		Limit(uint64(limit)).
+		Offset(uint64((page - 1) * limit))
 
 	rows, err := query.RunWith(s.db).Query()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get packet loss results: %w", err)
+		return nil, fmt.Errorf("failed to get packet loss result summaries: %w", err)
 	}
 	defer rows.Close()
 
-	var results []*types.PacketLossResult
+	results := make([]types.PacketLossResultSummary, 0, limit)
 	for rows.Next() {
-		result := &types.PacketLossResult{}
+		var result types.PacketLossResultSummary
 		err := rows.Scan(
 			&result.ID,
 			&result.MonitorID,
@@ -356,18 +371,58 @@ func (s *service) GetPacketLossResults(monitorID int64, limit int) ([]*types.Pac
 			&result.PacketsRecv,
 			&result.UsedMTR,
 			&result.HopCount,
-			&result.MTRData,
 			&result.PrivilegedMode,
 			&result.CreatedAt,
 		)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to scan packet loss result")
+			log.Error().Err(err).Msg("Failed to scan packet loss result summary")
 			continue
 		}
 		results = append(results, result)
 	}
 
-	return results, nil
+	return &types.PaginatedPacketLossResults{
+		Data:  results,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}, nil
+}
+
+// GetPacketLossResultDetail retrieves a single packet loss result including full MTR data.
+func (s *service) GetPacketLossResultDetail(monitorID int64, resultID int64) (*types.PacketLossResult, error) {
+	query := s.sqlBuilder.
+		Select("id", "monitor_id", "packet_loss", "min_rtt", "max_rtt", "avg_rtt", "std_dev_rtt", "packets_sent", "packets_recv", "used_mtr", "hop_count", "mtr_data", "privileged_mode", "created_at").
+		From("packet_loss_results").
+		Where(sq.Eq{"monitor_id": monitorID, "id": resultID}).
+		Limit(1)
+
+	result := &types.PacketLossResult{}
+	err := query.RunWith(s.db).QueryRow().Scan(
+		&result.ID,
+		&result.MonitorID,
+		&result.PacketLoss,
+		&result.MinRTT,
+		&result.MaxRTT,
+		&result.AvgRTT,
+		&result.StdDevRTT,
+		&result.PacketsSent,
+		&result.PacketsRecv,
+		&result.UsedMTR,
+		&result.HopCount,
+		&result.MTRData,
+		&result.PrivilegedMode,
+		&result.CreatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get packet loss result detail: %w", err)
+	}
+
+	return result, nil
 }
 
 // UpdatePacketLossMonitorState updates the monitor state and timestamp

--- a/internal/database/packetloss_integration_test.go
+++ b/internal/database/packetloss_integration_test.go
@@ -220,15 +220,57 @@ func TestGetPacketLossResults(t *testing.T) {
 		}
 
 		// Get results with limit
-		results, err := td.Service.GetPacketLossResults(monitor.ID, 5)
+		results, err := td.Service.GetPacketLossResults(monitor.ID, 1, 5)
 		require.NoError(t, err)
-		assert.Len(t, results, 5)
+		assert.Len(t, results.Data, 5)
+		assert.Equal(t, 10, results.Total)
+		assert.Equal(t, 1, results.Page)
+		assert.Equal(t, 5, results.Limit)
 
 		// Verify order (should be newest first)
-		for i := 1; i < len(results); i++ {
-			assert.True(t, results[i-1].CreatedAt.After(results[i].CreatedAt) ||
-				results[i-1].CreatedAt.Equal(results[i].CreatedAt))
+		for i := 1; i < len(results.Data); i++ {
+			assert.True(t, results.Data[i-1].CreatedAt.After(results.Data[i].CreatedAt) ||
+				results.Data[i-1].CreatedAt.Equal(results.Data[i].CreatedAt))
 		}
+	})
+}
+
+func TestGetPacketLossResultsStablePagination(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestPacketLossMonitor(t, td)
+		createdAt := time.Now().UTC().Truncate(time.Second)
+
+		for i := 0; i < 4; i++ {
+			result := &types.PacketLossResult{
+				MonitorID:   monitor.ID,
+				PacketLoss:  float64(i),
+				AvgRTT:      20.0 + float64(i),
+				PacketsSent: 10,
+				PacketsRecv: 10 - i,
+				CreatedAt:   createdAt,
+			}
+			err := td.Service.SavePacketLossResult(result)
+			require.NoError(t, err)
+		}
+
+		firstPage, err := td.Service.GetPacketLossResults(monitor.ID, 1, 2)
+		require.NoError(t, err)
+		require.Len(t, firstPage.Data, 2)
+
+		secondPage, err := td.Service.GetPacketLossResults(monitor.ID, 2, 2)
+		require.NoError(t, err)
+		require.Len(t, secondPage.Data, 2)
+
+		firstPageIDs := []int64{firstPage.Data[0].ID, firstPage.Data[1].ID}
+		secondPageIDs := []int64{secondPage.Data[0].ID, secondPage.Data[1].ID}
+
+		assert.NotEqual(t, firstPageIDs[0], firstPageIDs[1])
+		assert.NotEqual(t, secondPageIDs[0], secondPageIDs[1])
+		assert.NotContains(t, firstPageIDs, secondPageIDs[0])
+		assert.NotContains(t, firstPageIDs, secondPageIDs[1])
+		assert.Greater(t, firstPage.Data[0].ID, firstPage.Data[1].ID)
+		assert.Greater(t, secondPage.Data[0].ID, secondPage.Data[1].ID)
+		assert.Greater(t, firstPage.Data[1].ID, secondPage.Data[0].ID)
 	})
 }
 
@@ -307,5 +349,34 @@ func TestSavePacketLossResult_WithMTRData(t *testing.T) {
 		require.NotNil(t, latest.MTRData)
 		assert.Contains(t, *latest.MTRData, "192.168.1.1")
 		assert.Equal(t, 3, latest.HopCount)
+	})
+}
+
+func TestGetPacketLossResultDetail(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestPacketLossMonitor(t, td)
+
+		mtrData := `{"hops":[{"addr":"192.168.1.1","loss":0}]}`
+		result := &types.PacketLossResult{
+			MonitorID:      monitor.ID,
+			PacketLoss:     0.0,
+			AvgRTT:         10.0,
+			PacketsSent:    10,
+			PacketsRecv:    10,
+			UsedMTR:        true,
+			HopCount:       1,
+			MTRData:        &mtrData,
+			PrivilegedMode: false,
+			CreatedAt:      time.Now(),
+		}
+
+		err := td.Service.SavePacketLossResult(result)
+		require.NoError(t, err)
+
+		detail, err := td.Service.GetPacketLossResultDetail(monitor.ID, result.ID)
+		require.NoError(t, err)
+		require.NotNil(t, detail.MTRData)
+		assert.Equal(t, result.ID, detail.ID)
+		assert.Contains(t, *detail.MTRData, "192.168.1.1")
 	})
 }

--- a/internal/handlers/packetloss.go
+++ b/internal/handlers/packetloss.go
@@ -227,17 +227,23 @@ func (h *PacketLossHandler) GetMonitorHistory(c *gin.Context) {
 		return
 	}
 
-	// Get limit from query parameter
-	limitStr := c.DefaultQuery("limit", "100")
-	limit, err := strconv.Atoi(limitStr)
-	if err != nil || limit <= 0 {
-		limit = 100
-	}
-	if limit > 1000 {
-		limit = 1000 // Cap at 1000 results
+	pageStr := c.DefaultQuery("page", "1")
+	page, err := strconv.Atoi(pageStr)
+	if err != nil || page <= 0 {
+		page = 1
 	}
 
-	results, err := h.db.GetPacketLossResults(id, limit)
+	// Get limit from query parameter
+	limitStr := c.DefaultQuery("limit", "25")
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	results, err := h.db.GetPacketLossResults(id, page, limit)
 	if err != nil {
 		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to get packet loss results")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor history"})
@@ -245,6 +251,34 @@ func (h *PacketLossHandler) GetMonitorHistory(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, results)
+}
+
+// GetMonitorHistoryDetail returns a single historical result for a monitor, including MTR detail.
+func (h *PacketLossHandler) GetMonitorHistoryDetail(c *gin.Context) {
+	monitorID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid monitor ID"})
+		return
+	}
+
+	resultID, err := strconv.ParseInt(c.Param("resultId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid result ID"})
+		return
+	}
+
+	result, err := h.db.GetPacketLossResultDetail(monitorID, resultID)
+	if err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Result not found"})
+			return
+		}
+		log.Error().Err(err).Int64("monitorID", monitorID).Int64("resultID", resultID).Msg("Failed to get packet loss result detail")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor history detail"})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
 }
 
 // StartMonitor manually starts monitoring for a specific monitor
@@ -280,13 +314,13 @@ func (h *PacketLossHandler) StartMonitor(c *gin.Context) {
 	// Update last_run and next_run times before running the test
 	now := time.Now()
 	monitor.LastRun = &now
-	
+
 	// Calculate next run time based on the interval
 	nextRun := h.scheduler.CalculateNextRun(monitor.Interval, now)
 	if !nextRun.IsZero() {
 		monitor.NextRun = &nextRun
 	}
-	
+
 	// Update the monitor with new schedule times
 	if err := h.db.UpdatePacketLossMonitor(monitor); err != nil {
 		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to update monitor schedule")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -254,6 +254,7 @@ func (s *Server) RegisterRoutes() {
 				protected.DELETE("/packetloss/monitors/:id", packetLossHandler.DeleteMonitor)
 				protected.GET("/packetloss/monitors/:id/status", packetLossHandler.GetMonitorStatus)
 				protected.GET("/packetloss/monitors/:id/history", packetLossHandler.GetMonitorHistory)
+				protected.GET("/packetloss/monitors/:id/history/:resultId", packetLossHandler.GetMonitorHistoryDetail)
 				protected.POST("/packetloss/monitors/:id/start", packetLossHandler.StartMonitor)
 				protected.POST("/packetloss/monitors/:id/stop", packetLossHandler.StopMonitor)
 			}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -167,6 +167,29 @@ type PacketLossResult struct {
 	CreatedAt      time.Time `db:"created_at" json:"createdAt"`
 }
 
+type PacketLossResultSummary struct {
+	ID             int64     `db:"id" json:"id"`
+	MonitorID      int64     `db:"monitor_id" json:"monitorId"`
+	PacketLoss     float64   `db:"packet_loss" json:"packetLoss"`
+	MinRTT         float64   `db:"min_rtt" json:"minRtt"`
+	MaxRTT         float64   `db:"max_rtt" json:"maxRtt"`
+	AvgRTT         float64   `db:"avg_rtt" json:"avgRtt"`
+	StdDevRTT      float64   `db:"std_dev_rtt" json:"stdDevRtt"`
+	PacketsSent    int       `db:"packets_sent" json:"packetsSent"`
+	PacketsRecv    int       `db:"packets_recv" json:"packetsRecv"`
+	UsedMTR        bool      `db:"used_mtr" json:"usedMtr"`
+	HopCount       int       `db:"hop_count" json:"hopCount"`
+	PrivilegedMode bool      `db:"privileged_mode" json:"privilegedMode"`
+	CreatedAt      time.Time `db:"created_at" json:"createdAt"`
+}
+
+type PaginatedPacketLossResults struct {
+	Data  []PacketLossResultSummary `json:"data"`
+	Total int                       `json:"total"`
+	Page  int                       `json:"page"`
+	Limit int                       `json:"limit"`
+}
+
 // MonitorAgent represents a monitoring agent configuration
 type MonitorAgent struct {
 	ID                int64      `db:"id" json:"id"`

--- a/web/src/api/packetloss.ts
+++ b/web/src/api/packetloss.ts
@@ -7,7 +7,9 @@ import { getApiUrl } from "@/utils/baseUrl";
 import {
   PacketLossMonitor,
   PacketLossResult,
+  PacketLossResultDetail,
   PacketLossUpdate,
+  PaginatedResponse,
 } from "@/types/types";
 
 export const getPacketLossMonitors = async (): Promise<PacketLossMonitor[]> => {
@@ -74,13 +76,27 @@ export const getPacketLossMonitorStatus = async (
 
 export const getPacketLossHistory = async (
   id: number,
-  limit: number = 100,
-): Promise<PacketLossResult[]> => {
+  page: number = 1,
+  limit: number = 25,
+): Promise<PaginatedResponse<PacketLossResult>> => {
   const response = await fetch(
-    getApiUrl(`/packetloss/monitors/${id}/history?limit=${limit}`),
+    getApiUrl(`/packetloss/monitors/${id}/history?page=${page}&limit=${limit}`),
   );
   if (!response.ok) {
     throw new Error("Failed to fetch monitor history");
+  }
+  return response.json();
+};
+
+export const getPacketLossHistoryDetail = async (
+  id: number,
+  resultId: number,
+): Promise<PacketLossResultDetail> => {
+  const response = await fetch(
+    getApiUrl(`/packetloss/monitors/${id}/history/${resultId}`),
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch monitor history detail");
   }
   return response.json();
 };

--- a/web/src/components/speedtest/TracerouteTab.tsx
+++ b/web/src/components/speedtest/TracerouteTab.tsx
@@ -201,16 +201,10 @@ export const TracerouteTab: React.FC = () => {
     onMutate: (monitorId) => {
       setTogglingMonitorIds(prev => new Set(prev).add(monitorId));
     },
-    onSuccess: async (_, monitorId) => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ["packetloss", "monitors"] });
-      queryClient.invalidateQueries({
-        queryKey: ["packetloss", "history", monitorId],
-      });
       await queryClient.refetchQueries({
         queryKey: ["packetloss", "monitors"],
-      });
-      await queryClient.refetchQueries({
-        queryKey: ["packetloss", "history", monitorId],
       });
     },
     onSettled: (_, __, monitorId) => {
@@ -229,14 +223,8 @@ export const TracerouteTab: React.FC = () => {
     },
     onSuccess: async (_, monitorId) => {
       queryClient.invalidateQueries({ queryKey: ["packetloss", "monitors"] });
-      queryClient.invalidateQueries({
-        queryKey: ["packetloss", "history", monitorId],
-      });
       await queryClient.refetchQueries({
         queryKey: ["packetloss", "monitors"],
-      });
-      await queryClient.refetchQueries({
-        queryKey: ["packetloss", "history", monitorId],
       });
       const monitor = monitorList.find((m) => m.id === monitorId);
       showToast("Monitor stopped", "success", {
@@ -509,6 +497,7 @@ export const TracerouteTab: React.FC = () => {
           {/* Right Column - Monitor Details */}
           {selectedMonitor && (
             <PacketLossMonitorDetails
+              key={selectedMonitor.id}
               selectedMonitor={selectedMonitor}
               monitorStatuses={monitorStatuses}
             />

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorDetails.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import React, { useEffect } from "react";
+import React from "react";
 import { motion } from "motion/react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { GlobeAltIcon } from "@heroicons/react/24/outline";
 import { PacketLossMonitor } from "@/types/types";
 import { getPacketLossHistory } from "@/api/packetloss";
@@ -13,6 +13,7 @@ import { MonitorStatusCard } from "./components/MonitorStatusCard";
 import { MonitorPerformanceChart } from "./components/MonitorPerformanceChart";
 import { MonitorResultsTable } from "./components/MonitorResultsTable";
 import { MonitorStatus } from "./types/monitorStatus";
+import { PACKET_LOSS_HISTORY_PAGE_SIZE } from "./constants/packetLossConstants";
 
 interface PacketLossMonitorDetailsProps {
   selectedMonitor: PacketLossMonitor;
@@ -23,33 +24,38 @@ interface PacketLossMonitorDetailsProps {
 export const PacketLossMonitorDetails: React.FC<
   PacketLossMonitorDetailsProps
 > = ({ selectedMonitor, monitorStatuses, onTraceRoute }) => {
-  const queryClient = useQueryClient();
-
-  // Fetch history for selected monitor
-  const { data: monitorHistory } = useQuery({
+  const {
+    data: monitorHistory,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
     queryKey: ["packetloss", "history", selectedMonitor.id],
-    queryFn: () => getPacketLossHistory(selectedMonitor.id, 100),
+    queryFn: ({ pageParam }) =>
+      getPacketLossHistory(
+        selectedMonitor.id,
+        pageParam,
+        PACKET_LOSS_HISTORY_PAGE_SIZE,
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const loadedCount = allPages.reduce(
+        (total, page) => total + page.data.length,
+        0,
+      );
+
+      return loadedCount < (lastPage.total || 0)
+        ? lastPage.page + 1
+        : undefined;
+    },
     staleTime: 5000, // Consider data stale after 5 seconds
     refetchInterval: false, // Don't refetch automatically
   });
 
-  // Ensure monitorHistory is always an array
-  const historyList = monitorHistory || [];
-
-  // Fetch fresh history when monitor is selected
-  useEffect(() => {
-    // Fetch fresh data and update cache directly
-    getPacketLossHistory(selectedMonitor.id, 100)
-      .then((freshHistory) => {
-        queryClient.setQueryData(
-          ["packetloss", "history", selectedMonitor.id],
-          freshHistory,
-        );
-      })
-      .catch((error) => {
-        console.error("Failed to fetch monitor history:", error);
-      });
-  }, [selectedMonitor, queryClient]);
+  const historyList =
+    monitorHistory?.pages.flatMap((page) => page.data) || [];
+  const totalHistoryCount = monitorHistory?.pages[0]?.total || historyList.length;
+  const hasMoreHistory = hasNextPage || false;
 
   const status = monitorStatuses.get(selectedMonitor.id);
   const showStatus =
@@ -101,6 +107,10 @@ export const PacketLossMonitorDetails: React.FC<
         <MonitorResultsTable
           historyList={historyList}
           selectedMonitor={selectedMonitor}
+          totalCount={totalHistoryCount}
+          hasMore={hasMoreHistory}
+          isFetchingMore={isFetchingNextPage}
+          onLoadMore={() => void fetchNextPage()}
         />
       </div>
     </motion.div>

--- a/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx
+++ b/web/src/components/speedtest/packetloss/components/MonitorResultsTable.tsx
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
 import { ChevronUpDownIcon } from "@heroicons/react/24/solid";
-import { PacketLossResult, PacketLossMonitor } from "@/types/types";
+import {
+  PacketLossResult,
+  PacketLossMonitor,
+  PacketLossResultDetail,
+} from "@/types/types";
+import { getPacketLossHistoryDetail } from "@/api/packetloss";
 import { MTRResultsDisplay } from "./MTRResultsDisplay";
 import { formatRTT, parseMTRData } from "../utils/packetLossUtils";
 import { formatDateTimeWithSettings } from "@/utils/timeSettings";
@@ -14,25 +19,104 @@ import { formatDateTimeWithSettings } from "@/utils/timeSettings";
 interface MonitorResultsTableProps {
   historyList: PacketLossResult[];
   selectedMonitor: PacketLossMonitor;
+  totalCount: number;
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  onLoadMore: () => void;
 }
 
 export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
   historyList,
   selectedMonitor,
+  totalCount,
+  hasMore,
+  isFetchingMore,
+  onLoadMore,
 }) => {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-  const [displayCount, setDisplayCount] = useState(10);
+  const [detailCache, setDetailCache] = useState<Map<number, PacketLossResultDetail>>(
+    new Map(),
+  );
+  const [loadingDetails, setLoadingDetails] = useState<Set<number>>(new Set());
+  const [detailErrors, setDetailErrors] = useState<Set<number>>(new Set());
+  const expandedRowsRef = useRef(expandedRows);
 
-  const toggleExpanded = (resultId: number) => {
+  useEffect(() => {
+    expandedRowsRef.current = expandedRows;
+  }, [expandedRows]);
+
+  const toggleExpanded = async (result: PacketLossResult) => {
+    const isExpanded = expandedRows.has(result.id);
+
     setExpandedRows((prev) => {
       const newSet = new Set(prev);
-      if (newSet.has(resultId)) {
-        newSet.delete(resultId);
+      if (isExpanded) {
+        newSet.delete(result.id);
       } else {
-        newSet.add(resultId);
+        newSet.add(result.id);
       }
       return newSet;
     });
+
+    if (isExpanded) {
+      setDetailCache((prev) => {
+        const next = new Map(prev);
+        next.delete(result.id);
+        return next;
+      });
+      setDetailErrors((prev) => {
+        const next = new Set(prev);
+        next.delete(result.id);
+        return next;
+      });
+      return;
+    }
+
+    if (
+      !result.usedMtr ||
+      detailCache.has(result.id) ||
+      loadingDetails.has(result.id)
+    ) {
+      return;
+    }
+
+    setLoadingDetails((prev) => new Set(prev).add(result.id));
+    setDetailErrors((prev) => {
+      const next = new Set(prev);
+      next.delete(result.id);
+      return next;
+    });
+
+    try {
+      const detail = await getPacketLossHistoryDetail(
+        selectedMonitor.id,
+        result.id,
+      );
+
+      if (!expandedRowsRef.current.has(result.id)) {
+        return;
+      }
+
+      setDetailCache((prev) => {
+        const next = new Map(prev);
+        next.set(result.id, detail);
+        return next;
+      });
+    } catch (error) {
+      console.error("Failed to fetch MTR detail:", error);
+
+      if (!expandedRowsRef.current.has(result.id)) {
+        return;
+      }
+
+      setDetailErrors((prev) => new Set(prev).add(result.id));
+    } finally {
+      setLoadingDetails((prev) => {
+        const next = new Set(prev);
+        next.delete(result.id);
+        return next;
+      });
+    }
   };
 
   const formatDate = (dateStr: string) => {
@@ -43,8 +127,7 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
     <div>
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-gray-700 dark:text-gray-300 font-medium">
-          Recent Results{" "}
-          {historyList.length > 0 && `(${historyList.length} total)`}
+          Recent Results {totalCount > 0 && `(${totalCount} total)`}
         </h3>
         {historyList.some((result) => result.usedMtr) && (
           <p className="text-xs text-gray-500 dark:text-gray-500 hidden md:block">
@@ -82,9 +165,12 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
             </tr>
           </thead>
           <tbody>
-            {historyList.slice(0, displayCount).map((result) => {
-              const mtrData = parseMTRData(result.mtrData);
+            {historyList.map((result) => {
+              const detail = detailCache.get(result.id);
+              const mtrData = parseMTRData(detail?.mtrData);
               const isExpanded = expandedRows.has(result.id);
+              const isLoadingDetail = loadingDetails.has(result.id);
+              const hasDetailError = detailErrors.has(result.id);
 
               return (
                 <Fragment key={result.id}>
@@ -98,8 +184,8 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
                         : "hover:bg-gray-200/30 dark:hover:bg-gray-800/30"
                     }`}
                     onClick={() => {
-                      if (result.usedMtr && mtrData) {
-                        toggleExpanded(result.id);
+                      if (result.usedMtr) {
+                        void toggleExpanded(result);
                       }
                     }}
                   >
@@ -163,6 +249,20 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
                   </motion.tr>
 
                   {/* Expandable MTR Details Row */}
+                  {result.usedMtr && isExpanded && isLoadingDetail && (
+                    <tr className="bg-gray-100/50 dark:bg-gray-900/50">
+                      <td colSpan={8} className="p-4 text-sm text-gray-600 dark:text-gray-400">
+                        Loading MTR details...
+                      </td>
+                    </tr>
+                  )}
+                  {result.usedMtr && isExpanded && hasDetailError && (
+                    <tr className="bg-gray-100/50 dark:bg-gray-900/50">
+                      <td colSpan={8} className="p-4 text-sm text-red-600 dark:text-red-400">
+                        Failed to load MTR details.
+                      </td>
+                    </tr>
+                  )}
                   {result.usedMtr && mtrData && (
                     <MTRResultsDisplay
                       mtrData={mtrData}
@@ -177,13 +277,17 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
         </table>
 
         {/* Load More Button */}
-        {historyList.length > displayCount && (
+        {hasMore && (
           <div className="flex justify-center mt-4">
             <button
-              onClick={() => setDisplayCount((prev) => prev + 10)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onLoadMore();
+              }}
+              disabled={isFetchingMore}
               className="px-4 py-2 bg-gray-200/30 dark:bg-gray-800/30 border border-gray-300/50 dark:border-gray-900/50 text-gray-600/50 dark:text-gray-300/50 hover:text-gray-700 dark:hover:text-gray-300 rounded-lg hover:bg-gray-300/50 dark:hover:bg-gray-800/50 transition-colors"
             >
-              Load More
+              {isFetchingMore ? "Loading..." : "Load More"}
             </button>
           </div>
         )}
@@ -191,9 +295,12 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
 
       {/* Mobile Card View */}
       <div className="md:hidden space-y-3">
-        {historyList.slice(0, displayCount).map((result) => {
-          const mtrData = parseMTRData(result.mtrData);
+        {historyList.map((result) => {
+          const detail = detailCache.get(result.id);
+          const mtrData = parseMTRData(detail?.mtrData);
           const isExpanded = expandedRows.has(result.id);
+          const isLoadingDetail = loadingDetails.has(result.id);
+          const hasDetailError = detailErrors.has(result.id);
 
           return (
             <motion.div
@@ -207,8 +314,8 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
                   : ""
               }`}
               onClick={() => {
-                if (result.usedMtr && mtrData) {
-                  toggleExpanded(result.id);
+                if (result.usedMtr) {
+                  void toggleExpanded(result);
                 }
               }}
             >
@@ -285,6 +392,18 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
               </div>
 
               {/* Expandable MTR Details */}
+              {result.usedMtr && isExpanded && isLoadingDetail && (
+                <div className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+                  Loading MTR details...
+                </div>
+              )}
+
+              {result.usedMtr && isExpanded && hasDetailError && (
+                <div className="mt-3 text-sm text-red-600 dark:text-red-400">
+                  Failed to load MTR details.
+                </div>
+              )}
+
               {result.usedMtr && mtrData && (
                 <MTRResultsDisplay
                   mtrData={mtrData}
@@ -297,13 +416,17 @@ export const MonitorResultsTable: React.FC<MonitorResultsTableProps> = ({
         })}
 
         {/* Load More Button for Mobile */}
-        {historyList.length > displayCount && (
+        {hasMore && (
           <div className="flex justify-center mt-4">
             <button
-              onClick={() => setDisplayCount((prev) => prev + 10)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onLoadMore();
+              }}
+              disabled={isFetchingMore}
               className="px-4 py-2 bg-gray-200/30 dark:bg-gray-800/30 border border-gray-300/50 dark:border-gray-900/50 text-gray-600/50 dark:text-gray-300/50 hover:text-gray-700 dark:hover:text-gray-300 rounded-lg hover:bg-gray-300/50 dark:hover:bg-gray-800/50 transition-colors"
             >
-              Load More
+              {isFetchingMore ? "Loading..." : "Load More"}
             </button>
           </div>
         )}

--- a/web/src/components/speedtest/packetloss/constants/packetLossConstants.ts
+++ b/web/src/components/speedtest/packetloss/constants/packetLossConstants.ts
@@ -8,6 +8,8 @@ export interface IntervalOption {
   label: string;
 }
 
+export const PACKET_LOSS_HISTORY_PAGE_SIZE = 30;
+
 export const intervalOptions: IntervalOption[] = [
   { value: "10s", label: "Every 10 seconds" },
   { value: "30s", label: "Every 30 seconds" },

--- a/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts
+++ b/web/src/components/speedtest/packetloss/hooks/usePacketLossMonitorStatus.ts
@@ -4,13 +4,52 @@
  */
 
 import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { PacketLossMonitor } from "@/types/types";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 import {
-  getPacketLossMonitorStatus,
+  PacketLossMonitor,
+  PacketLossResult,
+  PaginatedResponse,
+} from "@/types/types";
+import {
   getPacketLossHistory,
+  getPacketLossMonitorStatus,
 } from "@/api/packetloss";
+import { PACKET_LOSS_HISTORY_PAGE_SIZE } from "../constants/packetLossConstants";
 import { MonitorStatus } from "../types/monitorStatus";
+
+const mergeLatestHistoryPage = (
+  previous: InfiniteData<PaginatedResponse<PacketLossResult>>,
+  latestPage: PaginatedResponse<PacketLossResult>,
+): InfiniteData<PaginatedResponse<PacketLossResult>> => {
+  const loadedCount = previous.pages.reduce(
+    (total, page) => total + page.data.length,
+    0,
+  );
+  const latestIDs = new Set(latestPage.data.map((result) => result.id));
+  const remainingResults = previous.pages
+    .flatMap((page) => page.data)
+    .filter((result) => !latestIDs.has(result.id));
+  const mergedResults = [...latestPage.data, ...remainingResults].slice(
+    0,
+    Math.min(loadedCount, latestPage.total || loadedCount),
+  );
+
+  return {
+    ...previous,
+    pages: previous.pages.map((page, index) => {
+      const start = index * PACKET_LOSS_HISTORY_PAGE_SIZE;
+      const end = start + PACKET_LOSS_HISTORY_PAGE_SIZE;
+
+      return {
+        ...page,
+        data: mergedResults.slice(start, end),
+        page: index + 1,
+        limit: latestPage.limit,
+        total: latestPage.total,
+      };
+    }),
+  };
+};
 
 export const usePacketLossMonitorStatus = (
   monitors: PacketLossMonitor[],
@@ -64,38 +103,51 @@ export const usePacketLossMonitorStatus = (
       for (const completedTest of completedTests) {
         if (!completedTest) continue;
 
+        const historyQueryKey = [
+          "packetloss",
+          "history",
+          completedTest.monitorId,
+        ] as const;
+
         // Refetch monitors list
         await queryClient.refetchQueries({
           queryKey: ["packetloss", "monitors"],
         });
 
-        // If this is the selected monitor, fetch fresh data and update cache directly
         if (completedTest.monitorId === selectedMonitorId) {
-          try {
-            // Fetch fresh history from the backend
-            const freshHistory = await getPacketLossHistory(
-              completedTest.monitorId,
-              100,
-            );
+          const cachedHistory = queryClient.getQueryData<
+            InfiniteData<PaginatedResponse<PacketLossResult>>
+          >(historyQueryKey);
 
-            // Directly update the cache with fresh data (like TracerouteTab does)
-            queryClient.setQueryData(
-              ["packetloss", "history", completedTest.monitorId],
-              freshHistory,
-            );
+          if (cachedHistory) {
+            try {
+              const latestHistory = await getPacketLossHistory(
+                completedTest.monitorId,
+                1,
+                PACKET_LOSS_HISTORY_PAGE_SIZE,
+              );
 
-            // Force React Query to notify all subscribers of the change
-            queryClient.invalidateQueries({
-              queryKey: ["packetloss", "history", completedTest.monitorId],
-              exact: true,
+              queryClient.setQueryData<
+                InfiniteData<PaginatedResponse<PacketLossResult>>
+              >(historyQueryKey, (previous) =>
+                previous
+                  ? mergeLatestHistoryPage(previous, latestHistory)
+                  : previous,
+              );
+            } catch (error) {
+              console.error("Failed to refresh latest history page:", error);
+              await queryClient.invalidateQueries({
+                queryKey: historyQueryKey,
+              });
+            }
+          } else {
+            await queryClient.invalidateQueries({
+              queryKey: historyQueryKey,
             });
-          } catch (error) {
-            console.error("Failed to fetch updated history:", error);
           }
         } else {
-          // For other monitors, just invalidate to mark as stale
           await queryClient.invalidateQueries({
-            queryKey: ["packetloss", "history", completedTest.monitorId],
+            queryKey: historyQueryKey,
           });
         }
 

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -168,9 +168,12 @@ export interface PacketLossResult {
   packetsRecv: number;
   usedMtr?: boolean;
   hopCount?: number;
-  mtrData?: string; // JSON string containing MTRData
   privilegedMode?: boolean;
   createdAt: string;
+}
+
+export interface PacketLossResultDetail extends PacketLossResult {
+  mtrData?: string;
 }
 
 export interface MTRHop {


### PR DESCRIPTION
## Summary
- split packet-loss history into paginated summary rows plus lazy per-result MTR detail
- remove `mtrData` from the normal history payload and keep the existing expand UI via a detail fetch
- add monitor history ordering/index changes and refresh the frontend cache without broad history refetches

## Why
- 1-minute packet-loss/MTR history was loading blob-heavy rows into the normal history path and growing memory pressure over time
- this keeps the current UI behavior while hard-cutting the main history payload down to summary data

## Testing
- [ ] `pnpm -C web lint`
- [x] `pnpm -C web build`
- [x] Other: `go test ./...`

## Screenshots (if UI)
- N/A

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [ ] AI-assisted changes reviewed and edited by a human


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Packet loss history now uses pagination with "Load More" functionality for faster initial page loads
  * MTR details load on-demand when expanding rows, improving performance and reducing data transfer

* **Performance Improvements**
  * Optimized packet loss history queries with new database indexes for faster retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->