### PR TITLE
fix(speedtest): fall back to unfiltered server list when no servers are pingable

### DIFF
--- a/internal/speedtest/speedtest_net.go
+++ b/internal/speedtest/speedtest_net.go
@@ -319,10 +319,19 @@ func (r *SpeedtestNetRunner) GetServers() ([]ServerResponse, error) {
 		return nil, fmt.Errorf("failed to fetch servers: %w", err)
 	}
 
+	// Available() drops servers whose HTTP ping failed during FetchServers().
+	// In restricted networks (e.g. Docker) all pings time out, leaving an empty
+	// (non-nil) slice, so fall back to the unfiltered list to keep the selectable
+	// server list populated.
 	availableServers := serverList.Available()
-	if availableServers == nil {
-		log.Error().Msg("No available speedtest servers found")
-		return nil, fmt.Errorf("no available servers found")
+	if availableServers == nil || len(*availableServers) == 0 {
+		log.Warn().Msg("No pingable speedtest servers, falling back to unfiltered server list")
+		availableServers = &serverList
+	}
+
+	if len(*availableServers) == 0 {
+		log.Error().Msg("No speedtest servers found")
+		return nil, fmt.Errorf("no speedtest servers found")
 	}
 
 	response := make([]ServerResponse, len(*availableServers))


### PR DESCRIPTION
The speedtest server list endpoint returned `200` with an empty list and no error when running in Docker/restricted networks. speedtest-go pings every server during `FetchServers()` under a short global timeout; `Available()` keeps only servers whose ping succeeded and returns an empty **non-nil** slice when they all time out, so the existing `== nil` guard never fired. `RunTest` uses the unfiltered list, which is why default tests kept working while the selectable list was empty. Now `GetServers()` falls back to the unfiltered list when the ping-filtered one is empty, and returns an actual error if even that list is empty. Normal networks are unaffected — the fallback only triggers when the filtered list is completely empty.

Tested with `go build ./...`, `go vet`, `go test ./internal/speedtest/...`, and a live run: `/api/servers?testType=speedtest` returns a populated, distance-sorted list.

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speed test server selection when ping checks time out or return no results.
  * Automatically falls back to the available server list so speed tests can continue in restricted network environments.
  * Reports an error only when no speed test servers are available at all.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->