### PR TITLE
feat(notifications): set title in shoutrrr notification payloads

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containrrr/shoutrrr"
 	"github.com/containrrr/shoutrrr/pkg/router"
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/netronome/internal/database"
@@ -98,6 +99,16 @@ func (n *Notifier) getThresholdForEvent(category, eventType string) *float64 {
 	return nil
 }
 
+// notificationTitle builds the shoutrrr notification title from a category.
+func notificationTitle(category string) string {
+	if category == "" {
+		return "Netronome"
+	}
+	label := strings.ReplaceAll(category, "_", " ")
+	label = strings.ToUpper(label[:1]) + label[1:]
+	return "Netronome: " + label
+}
+
 // SendNotification sends a notification for a specific event
 func (n *Notifier) SendNotification(category, eventType string, message string, value *float64) error {
 	if n.db == nil {
@@ -163,7 +174,8 @@ func (n *Notifier) SendNotification(category, eventType string, message string, 
 					continue
 				}
 
-				errs := tempNotifier.Send(message, nil)
+				params := types.Params{types.TitleKey: notificationTitle(category)}
+				errs := tempNotifier.Send(message, &params)
 				for _, err := range errs {
 					if err != nil {
 						sendErr = err
@@ -385,7 +397,8 @@ func (n *Notifier) sendDirect(message string) error {
 	}
 
 	if n.router != nil {
-		for _, err := range n.router.Send(message, nil) {
+		params := types.Params{types.TitleKey: "Netronome"}
+		for _, err := range n.router.Send(message, &params) {
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -101,12 +101,14 @@ func (n *Notifier) getThresholdForEvent(category, eventType string) *float64 {
 
 // notificationTitle builds the shoutrrr notification title from a category.
 func notificationTitle(category string) string {
-	if category == "" {
+	switch category {
+	case "":
 		return "Netronome"
+	case database.NotificationCategoryPacketLoss:
+		return "Netronome: Packet Loss"
+	default:
+		return "Netronome: " + strings.ToUpper(category[:1]) + category[1:]
 	}
-	label := strings.ReplaceAll(category, "_", " ")
-	label = strings.ToUpper(label[:1]) + label[1:]
-	return "Netronome: " + label
 }
 
 // SendNotification sends a notification for a specific event

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -19,7 +19,7 @@ func TestNotificationTitle(t *testing.T) {
 	}{
 		{"", "Netronome"},
 		{"speedtest", "Netronome: Speedtest"},
-		{"packet_loss", "Netronome: Packet loss"},
+		{"packetloss", "Netronome: Packet Loss"},
 		{"agent", "Netronome: Agent"},
 	}
 

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package notifications
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNotificationTitle(t *testing.T) {
+	tests := []struct {
+		category string
+		want     string
+	}{
+		{"", "Netronome"},
+		{"speedtest", "Netronome: Speedtest"},
+		{"packet_loss", "Netronome: Packet loss"},
+		{"agent", "Netronome: Agent"},
+	}
+
+	for _, tt := range tests {
+		if got := notificationTitle(tt.category); got != tt.want {
+			t.Errorf("notificationTitle(%q) = %q, want %q", tt.category, got, tt.want)
+		}
+	}
+}
+
+func TestSendDirectSetsTitle(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+
+	url := "generic://" + strings.TrimPrefix(srv.URL, "http://") + "?template=json&disabletls=yes"
+	notifier, err := NewNotifierFromURLs([]string{url})
+	if err != nil {
+		t.Fatalf("NewNotifierFromURLs: %v", err)
+	}
+
+	if err := notifier.sendDirect("hello"); err != nil {
+		t.Fatalf("sendDirect: %v", err)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal payload %q: %v", body, err)
+	}
+	if payload["title"] != "Netronome" {
+		t.Errorf("payload title = %q, want %q", payload["title"], "Netronome")
+	}
+	if payload["message"] != "hello" {
+		t.Errorf("payload message = %q, want %q", payload["message"], "hello")
+	}
+}


### PR DESCRIPTION
Sets the shoutrrr `title` param (`Netronome: <Category>` in rule-based notifications, `Netronome` for direct/test sends) so services with separate titles — e.g. the generic webhook with `template=json` — no longer emit an empty `"title"` field. ntfy uses its own raw-HTTP path and is unaffected.

Tested with `go test ./internal/notifications/...` (new payload test via httptest generic webhook) and live: ran the server and POSTed `/api/notifications/test` against a local `generic://…?template=json` capture — payload now contains `"title":"Netronome"`.

Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notifications now include clear, category-specific titles to make alerts easier to identify.
  - Direct notifications now display the “Netronome” title consistently.

- **Bug Fixes**
  - Improved notification delivery so titles are included across supported sending methods.

- **Tests**
  - Added coverage for category-to-title mapping and verified the direct notification JSON payload includes `title` and `message`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->