### PR TITLE
docs(auth): document disabling auth entirely via whitelist for reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,21 @@ Add to `config.toml`:
 whitelist = ["127.0.0.1/32", "192.168.1.0/24"]
 ```
 
+To disable authentication entirely — e.g. when a reverse proxy (SWAG/NGINX, Authelia, TinyAuth) already handles it — whitelist all clients. IPv6 needs its own entry alongside IPv4:
+
+```toml
+[auth]
+whitelist = ["0.0.0.0/0", "::/0"]
+```
+
+Or via environment variable (comma-separated, no spaces):
+
+```bash
+export NETRONOME__AUTH_WHITELIST=0.0.0.0/0,::/0
+```
+
+**Warning:** only do this when Netronome is not directly reachable — bind it to localhost or a proxy-only Docker network. Every client that can reach it gets full access.
+
 ### Database
 
 #### SQLite (Default)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -762,7 +762,10 @@ func (c *Config) WriteToml(w io.Writer) error {
 	if _, err := fmt.Fprintln(w, "# Example: whitelist = [\"127.0.0.1/32\"]"); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(w, "# To disable auth entirely behind a trusted reverse proxy: whitelist = [\"0.0.0.0/0\", \"::/0\"]"); err != nil {
+	if _, err := fmt.Fprintln(w, "# To disable auth entirely behind a trusted reverse proxy, replace the whitelist value below with:"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# whitelist = [\"0.0.0.0/0\", \"::/0\"]"); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, "# Only do this when Netronome is not directly reachable; every client that can reach it gets full access."); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -762,6 +762,12 @@ func (c *Config) WriteToml(w io.Writer) error {
 	if _, err := fmt.Fprintln(w, "# Example: whitelist = [\"127.0.0.1/32\"]"); err != nil {
 		return err
 	}
+	if _, err := fmt.Fprintln(w, "# To disable auth entirely behind a trusted reverse proxy: whitelist = [\"0.0.0.0/0\", \"::/0\"]"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Only do this when Netronome is not directly reachable; every client that can reach it gets full access."); err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintln(w, "whitelist = []"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Disabling built-in auth behind a reverse proxy is already supported via the existing `[auth] whitelist` CIDR config — `whitelist = ["0.0.0.0/0", "::/0"]` (or `NETRONOME__AUTH_WHITELIST=0.0.0.0/0,::/0`) bypasses auth for every client, and `Verify`/`GetUserInfo` honor the whitelist so the UI skips the login screen entirely. This documents that recipe in the README's IP Whitelisting section and in the generated `config.toml` comment, with a warning to only use it when Netronome is bound to localhost or a proxy-only network. Note the IPv6 entry (`::/0`) is required alongside `0.0.0.0/0` — `net.ParseCIDR` networks are family-specific — and the env form must be comma-separated without spaces since parsing doesn't trim.

Verified by running the server with the whitelist set: `/api/auth/verify` and `/api/auth/user` return 200 without a session (401 without the whitelist), and the UI loads straight to the dashboard with no login screen on a fresh DB. Closes #237.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded “Authentication → IP Whitelisting” instructions with an option to disable authentication using permissive IPv4/IPv6 CIDR whitelist entries.
  * Added a TOML example (`auth.whitelist`) and an environment-variable example (`NETRONOME__AUTH_WHITELIST`).
  * Included a prominent security warning that disabling authentication grants full access to any client that can reach the service, recommending localhost binding or a trusted proxy-only setup.
  * Updated the generated configuration example to match the new guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->