### PR TITLE
fix(speedtest): persist results when test overruns configured timeout

### DIFF
--- a/internal/speedtest/result_handler.go
+++ b/internal/speedtest/result_handler.go
@@ -57,8 +57,9 @@ func (h *DefaultResultHandler) SaveResult(ctx context.Context, result *Result, t
 		jitterPtr = &result.Jitter
 	}
 
-	// Give the DB write up to 10s while still respecting upstream cancellations and values.
-	saveCtx, saveCancel := context.WithTimeout(ctx, 10*time.Second)
+	// Give the DB write up to 10s, detached from the caller's deadline/cancellation
+	// (a test that overran the speedtest timeout must still persist its result) while keeping values.
+	saveCtx, saveCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer saveCancel()
 
 	createdAt := time.Now().UTC()


### PR DESCRIPTION
When a speed test runs longer than the configured `[speedtest] timeout` (slow/distant server), the test itself completes but saving fails with `failed to save speed test: context deadline exceeded` and the result is silently lost — `SaveResult` built its 10s DB-write timeout on the already-expired test context. This detaches the save context with `context.WithoutCancel`, so the write (and the notification that follows it) gets its own 10s budget while keeping context values.

Tested: `go test ./internal/speedtest/...`, plus a live run with `timeout = 5` — a full speedtest.net test overran the deadline and the result now saves and shows up in history (previously logged `Failed to save test result` and was lost).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speed test results are now saved even when the originating request is cancelled or times out.
  * Database writes remain bounded by a 10-second timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->