### PR TITLE
feat(data): allow purging historic speedtest and packet loss results

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -118,6 +118,7 @@ type Service interface {
 	GetMonitorLatestSnapshot(ctx context.Context, agentID int64, periodType string) (*types.MonitorHistoricalSnapshot, error)
 
 	CleanupMonitorData(ctx context.Context) error
+	PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, err error)
 
 	// Embed NotificationService interface
 	NotificationService

--- a/internal/database/purge.go
+++ b/internal/database/purge.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"context"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/rs/zerolog/log"
+)
+
+// PurgeHistoricalData deletes speed test and packet loss results older than the
+// given cutoff. On SQLite it runs VACUUM afterwards so the on-disk file actually
+// shrinks (VACUUM cannot run inside a transaction). A failed VACUUM is logged but
+// does not fail the call since the rows are already gone.
+func (s *service) PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, err error) {
+	log.Info().Time("before", before).Msg("Purging historical data")
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer tx.Rollback()
+
+	stResult, err := s.sqlBuilder.Delete("speed_tests").Where(sq.Lt{"created_at": before}).RunWith(tx).ExecContext(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to purge speed tests")
+		return 0, 0, err
+	}
+	speedTests, _ = stResult.RowsAffected()
+
+	plResult, err := s.sqlBuilder.Delete("packet_loss_results").Where(sq.Lt{"created_at": before}).RunWith(tx).ExecContext(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to purge packet loss results")
+		return 0, 0, err
+	}
+	packetLoss, _ = plResult.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		log.Error().Err(err).Msg("Failed to commit purge transaction")
+		return 0, 0, err
+	}
+
+	log.Info().Int64("speed_tests", speedTests).Int64("packet_loss", packetLoss).Msg("Purged historical data")
+
+	if s.config.Type == "sqlite" {
+		if _, err := s.db.ExecContext(ctx, "VACUUM"); err != nil {
+			log.Warn().Err(err).Msg("Failed to VACUUM after purge; database file will not shrink")
+		} else if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			// in WAL mode the file only shrinks once the WAL is checkpointed
+			log.Warn().Err(err).Msg("Failed to checkpoint WAL after purge")
+		}
+	}
+
+	return speedTests, packetLoss, nil
+}

--- a/internal/database/purge_integration_test.go
+++ b/internal/database/purge_integration_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+func TestPurgeHistoricalData(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		ctx := context.Background()
+
+		now := time.Now()
+		old := now.Add(-30 * 24 * time.Hour)   // 30 days ago
+		recent := now.Add(-1 * time.Hour)      // 1 hour ago
+		cutoff := now.Add(-7 * 24 * time.Hour) // 7 days ago (between old and recent)
+
+		// speed_tests: one old, one recent
+		_, err := td.Service.SaveSpeedTest(ctx, types.SpeedTestResult{
+			ServerName: "old", ServerID: "old", TestType: "speedtest", CreatedAt: old,
+		})
+		require.NoError(t, err)
+		recentST, err := td.Service.SaveSpeedTest(ctx, types.SpeedTestResult{
+			ServerName: "recent", ServerID: "recent", TestType: "speedtest", CreatedAt: recent,
+		})
+		require.NoError(t, err)
+
+		// packet_loss_results: needs a monitor (FK), one old, one recent
+		monitor := CreateTestPacketLossMonitor(t, td)
+		oldPL := &types.PacketLossResult{MonitorID: monitor.ID, PacketsSent: 10, PacketsRecv: 10, CreatedAt: old}
+		require.NoError(t, td.Service.SavePacketLossResult(oldPL))
+		recentPL := &types.PacketLossResult{MonitorID: monitor.ID, PacketsSent: 10, PacketsRecv: 10, CreatedAt: recent}
+		require.NoError(t, td.Service.SavePacketLossResult(recentPL))
+
+		// Purge everything older than the cutoff.
+		speedTests, packetLoss, err := td.Service.PurgeHistoricalData(ctx, cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), speedTests)
+		assert.Equal(t, int64(1), packetLoss)
+
+		// Only the recent rows should survive.
+		AssertRecordExists(t, td, "speed_tests", "id", recentST.ID)
+		AssertRecordExists(t, td, "packet_loss_results", "id", recentPL.ID)
+
+		var stCount, plCount int
+		require.NoError(t, td.DB.QueryRow("SELECT COUNT(*) FROM speed_tests").Scan(&stCount))
+		require.NoError(t, td.DB.QueryRow("SELECT COUNT(*) FROM packet_loss_results").Scan(&plCount))
+		assert.Equal(t, 1, stCount)
+		assert.Equal(t, 1, plCount)
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -295,6 +295,8 @@ func (s *Server) RegisterRoutes() {
 
 			protected.GET("/settings/dashboard", s.handleGetDashboardSettings)
 			protected.PUT("/settings/dashboard", s.handleUpdateDashboardSettings)
+
+			protected.POST("/history/purge", s.handlePurgeHistory)
 		}
 	}
 

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -6,6 +6,7 @@ package server
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -81,6 +82,40 @@ func (s *Server) handleUpdateDashboardSettings(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, dashboardSettingsResponse{RecentSpeedtestsRows: req.RecentSpeedtestsRows})
+}
+
+type purgeHistoryRequest struct {
+	OlderThanDays int `json:"olderThanDays"`
+}
+
+type purgeHistoryResponse struct {
+	SpeedTests int64 `json:"speedTests"`
+	PacketLoss int64 `json:"packetLoss"`
+}
+
+func (s *Server) handlePurgeHistory(c *gin.Context) {
+	var req purgeHistoryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	if req.OlderThanDays < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "olderThanDays must be >= 0"})
+		return
+	}
+
+	// olderThanDays == 0 means purge everything (cutoff = now)
+	before := time.Now().AddDate(0, 0, -req.OlderThanDays)
+
+	speedTests, packetLoss, err := s.db.PurgeHistoricalData(c.Request.Context(), before)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to purge historical data")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to purge historical data"})
+		return
+	}
+
+	c.JSON(http.StatusOK, purgeHistoryResponse{SpeedTests: speedTests, PacketLoss: packetLoss})
 }
 
 func isAllowedDashboardRecentRows(rows int) bool {

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -85,7 +85,7 @@ func (s *Server) handleUpdateDashboardSettings(c *gin.Context) {
 }
 
 type purgeHistoryRequest struct {
-	OlderThanDays int `json:"olderThanDays"`
+	OlderThanDays *int `json:"olderThanDays"`
 }
 
 type purgeHistoryResponse struct {
@@ -95,18 +95,19 @@ type purgeHistoryResponse struct {
 
 func (s *Server) handlePurgeHistory(c *gin.Context) {
 	var req purgeHistoryRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err := c.ShouldBindJSON(&req); err != nil || req.OlderThanDays == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 		return
 	}
 
-	if req.OlderThanDays < 0 {
+	if *req.OlderThanDays < 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "olderThanDays must be >= 0"})
 		return
 	}
 
-	// olderThanDays == 0 means purge everything (cutoff = now)
-	before := time.Now().AddDate(0, 0, -req.OlderThanDays)
+	// olderThanDays == 0 means purge everything (cutoff = now); nil (field
+	// missing or null) is rejected above so a malformed body can't purge all.
+	before := time.Now().AddDate(0, 0, -*req.OlderThanDays)
 
 	speedTests, packetLoss, err := s.db.PurgeHistoricalData(c.Request.Context(), before)
 	if err != nil {

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -38,6 +38,11 @@ export interface DashboardSettings {
   recentSpeedtestsRows: number;
 }
 
+export interface PurgeHistoryResult {
+  speedTests: number;
+  packetLoss: number;
+}
+
 export const settingsApi = {
   getDashboardSettings: async (): Promise<DashboardSettings> => {
     const response = await fetch(getApiUrl("/settings/dashboard"), {
@@ -57,6 +62,17 @@ export const settingsApi = {
       body: JSON.stringify(input),
     });
     await assertOk(response, "Failed to update dashboard settings");
+    return response.json();
+  },
+
+  purgeHistory: async (olderThanDays: number): Promise<PurgeHistoryResult> => {
+    const response = await fetch(getApiUrl("/history/purge"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ olderThanDays }),
+    });
+    await assertOk(response, "Failed to purge history");
     return response.json();
   },
 };

--- a/web/src/components/SettingsMenu.tsx
+++ b/web/src/components/SettingsMenu.tsx
@@ -10,11 +10,13 @@ import {
   ClockIcon,
   MapPinIcon,
   PresentationChartLineIcon,
+  CircleStackIcon,
 } from "@heroicons/react/24/outline";
 import { NotificationSettings } from "./settings/NotificationSettings";
 import { TimeFormatSettings } from "./settings/TimeFormatSettings";
 import { DistanceSettings } from "./settings/DistanceSettings";
 import { DashboardSettings } from "./settings/DashboardSettings";
+import { DataSettings } from "./settings/DataSettings";
 import { Button } from "@/components/ui/Button";
 import {
   Dialog,
@@ -60,6 +62,12 @@ const settingsSections: SettingsSection[] = [
     label: "Dashboard",
     icon: <PresentationChartLineIcon className="w-4 h-4" />,
     component: DashboardSettings,
+  },
+  {
+    id: "data",
+    label: "Data",
+    icon: <CircleStackIcon className="w-4 h-4" />,
+    component: DataSettings,
   },
 ];
 

--- a/web/src/components/settings/DataSettings.tsx
+++ b/web/src/components/settings/DataSettings.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import React, { useState } from "react";
+import { CircleStackIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/Button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DeleteConfirmationDialog } from "@/components/common/DeleteConfirmationDialog";
+import { settingsApi } from "@/api/settings";
+import { showToast } from "@/components/common/Toast";
+
+const RETENTION_OPTIONS = [
+  { value: 7, label: "older than 7 days" },
+  { value: 30, label: "older than 30 days" },
+  { value: 90, label: "older than 90 days" },
+  { value: 365, label: "older than 1 year" },
+  { value: 0, label: "everything" },
+];
+
+export const DataSettings: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [olderThanDays, setOlderThanDays] = useState(30);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () => settingsApi.purgeHistory(olderThanDays),
+    onSuccess: (result) => {
+      setConfirmOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["history"] });
+      queryClient.invalidateQueries({ queryKey: ["packetloss"] });
+      showToast("History purged", "success", {
+        description: `Deleted ${result.speedTests} speedtests and ${result.packetLoss} packet loss records`,
+      });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : undefined;
+      showToast("Failed to purge history", "error", {
+        description: message,
+      });
+    },
+  });
+
+  const selected = RETENTION_OPTIONS.find((o) => o.value === olderThanDays);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+          <CircleStackIcon className="w-6 h-6 text-gray-600 dark:text-gray-400" />
+          Data Settings
+        </h3>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Purge historic speedtest and packet loss results
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrashIcon className="w-5 h-5 text-red-600 dark:text-red-400" />
+            Purge History
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Delete records
+            </label>
+            <Select
+              value={String(olderThanDays)}
+              onValueChange={(value) => setOlderThanDays(Number(value))}
+            >
+              <SelectTrigger className="w-full sm:w-[240px]">
+                <SelectValue placeholder="Select retention window" />
+              </SelectTrigger>
+              <SelectContent>
+                {RETENTION_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={String(option.value)}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Permanently deletes speedtest and packet loss history. This action cannot be undone.
+          </p>
+
+          <Button
+            onClick={() => setConfirmOpen(true)}
+            disabled={mutation.isPending}
+            variant="destructive"
+          >
+            <TrashIcon className="w-4 h-4" />
+            Purge
+          </Button>
+        </CardContent>
+      </Card>
+
+      <DeleteConfirmationDialog
+        isOpen={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => mutation.mutate()}
+        title="Purge History"
+        itemName=""
+        description={`Permanently delete ${selected?.value === 0 ? "all history" : `history ${selected?.label}`}? This action cannot be undone.`}
+        isDeleting={mutation.isPending}
+      />
+    </div>
+  );
+};

--- a/web/src/components/settings/DataSettings.tsx
+++ b/web/src/components/settings/DataSettings.tsx
@@ -37,6 +37,7 @@ export const DataSettings: React.FC = () => {
     onSuccess: (result) => {
       setConfirmOpen(false);
       queryClient.invalidateQueries({ queryKey: ["history"] });
+      queryClient.invalidateQueries({ queryKey: ["history-chart"] });
       queryClient.invalidateQueries({ queryKey: ["packetloss"] });
       showToast("History purged", "success", {
         description: `Deleted ${result.speedTests} speedtests and ${result.packetLoss} packet loss records`,


### PR DESCRIPTION
Adds a purge for historic data (#198): `PurgeHistoricalData` deletes `speed_tests` and `packet_loss_results` rows older than a chosen cutoff, then runs `VACUUM` + `PRAGMA wal_checkpoint(TRUNCATE)` on SQLite so the database file actually shrinks on disk (the reporter's DB grows ~500MB/week, mostly `mtr_data`). Exposed as `POST /api/history/purge` (`{"olderThanDays": N}`, 0 = everything) and a new **Data** panel in the settings menu with a retention select and confirm dialog.

Tested with `go test ./internal/database/ ./internal/server/` (new `TestPurgeHistoricalData` passes on both SQLite and embedded PostgreSQL) and verified live: seeded a 4.2MB SQLite DB, purged via API and UI — file shrank to 192KB, counts and validation correct, toast reports deleted rows.

Closes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Data section to Settings for managing historical records.
  - Users can purge speed test and packet loss data older than 7, 30, 90, or 365 days—or remove all historical data.
  - Added confirmation prompts and success notifications showing the number of deleted records.

- **Bug Fixes**
  - Recent records remain preserved when older history is purged.

- **Tests**
  - Added coverage verifying retention cutoffs and deletion results across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->