### PR TITLE
fix(auth): only trust proxy headers from configured trusted proxies

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -472,7 +472,13 @@ func (c *Config) loadAuthFromEnv() {
 		c.Auth.Whitelist = strings.Split(v, ",")
 	}
 	if v := getEnv("AUTH_TRUSTED_PROXIES"); v != "" {
-		c.Auth.TrustedProxies = strings.Split(v, ",")
+		var proxies []string
+		for _, p := range strings.Split(v, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				proxies = append(proxies, p)
+			}
+		}
+		c.Auth.TrustedProxies = proxies
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,8 @@ type LoggingConfig struct {
 }
 
 type AuthConfig struct {
-	Whitelist []string `toml:"whitelist" env:"AUTH_WHITELIST"`
+	Whitelist      []string `toml:"whitelist" env:"AUTH_WHITELIST"`
+	TrustedProxies []string `toml:"trusted_proxies" env:"AUTH_TRUSTED_PROXIES"`
 }
 
 type OIDCConfig struct {
@@ -470,6 +471,9 @@ func (c *Config) loadAuthFromEnv() {
 	if v := getEnv("AUTH_WHITELIST"); v != "" {
 		c.Auth.Whitelist = strings.Split(v, ",")
 	}
+	if v := getEnv("AUTH_TRUSTED_PROXIES"); v != "" {
+		c.Auth.TrustedProxies = strings.Split(v, ",")
+	}
 }
 
 func (c *Config) loadOIDCFromEnv() {
@@ -763,6 +767,21 @@ func (c *Config) WriteToml(w io.Writer) error {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, "whitelist = []"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Only trust proxy headers (X-Forwarded-For, X-Real-IP) from these addresses, using IPs or CIDR notation."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Empty list = headers ignored, the client IP is always the direct peer. Set this when running behind a"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# reverse proxy so the whitelist above matches real client IPs."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Example: trusted_proxies = [\"172.16.0.0/12\"]"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "trusted_proxies = []"); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, ""); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,10 @@ func NewServer(speedtest speedtest.Service, db database.Service, scheduler sched
 
 	router := gin.New()
 
+	if err := router.SetTrustedProxies(cfg.Auth.TrustedProxies); err != nil {
+		log.Error().Err(err).Msg("failed to set trusted proxies")
+	}
+
 	// Initialize OIDC if configured
 	oidcConfig, err := auth.NewOIDC(context.Background(), cfg.OIDC)
 	if err != nil {


### PR DESCRIPTION
Gin's default trusts every peer as a proxy, so `c.ClientIP()` honored `X-Forwarded-For` from any client — making the `[auth]` whitelist bypass spoofable by anyone who can reach the server directly. This adds `[auth] trusted_proxies` (`NETRONOME__AUTH_TRUSTED_PROXIES`) wired to `router.SetTrustedProxies`, defaulting to an empty list: proxy headers are ignored and the client IP is always the direct peer. Follow-up hardening to #243 / #237.

**Migration note:** deployments using the whitelist *behind a reverse proxy* must set `trusted_proxies = ["<proxy IP or CIDR>"]` after upgrading, or whitelist matching will see the proxy's address instead of the client's. Verified live (`go build`, `go vet`, `go test ./internal/server ./internal/config`, plus curl against a running instance): spoofed XFF now gets 401 with the default, is honored only from a configured trusted proxy, and direct-peer whitelisting is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for specifying trusted proxy addresses.
  * Trusted proxies can be configured through environment variables or the generated TOML configuration.
  * The server now uses trusted proxy settings when processing requests.

* **Bug Fixes**
  * Invalid trusted proxy configuration is logged without preventing server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->