### PR TITLE
feat(monitor): remove 3-agent cap on dashboard featured agents

### DIFF
--- a/web/src/components/monitor/MonitorAgentList.tsx
+++ b/web/src/components/monitor/MonitorAgentList.tsx
@@ -530,13 +530,6 @@ const AgentActionsCell: React.FC<AgentActionsCellProps> = ({
         setFeaturedAgentIds(existingFeatured);
       }
 
-      if (existingFeatured.length >= 3) {
-        showToast("Feature limit reached", "error", {
-          description: "You can only feature up to 3 agents at a time",
-        });
-        return;
-      }
-
       if (existingFeatured.includes(agent.id)) {
         setIsFeatured(true);
         return;


### PR DESCRIPTION
Removes the arbitrary limit of 3 featured (pinned) agents on the dashboard. The featured widget grid already wraps to accommodate any number of agents, so the cap in `MonitorAgentList` was the only thing enforcing it.

No open issue tracks this; searched for a matching feature request and found none. Tested with `pnpm -C web lint` (only pre-existing failures, none in the touched file) and `tsc --noEmit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the limit on how many agents can be featured.
  * Agents can now be featured without being blocked by a “Feature limit reached” message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->