### PR TITLE
fix(config): apply the deprecated tailscale section migration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -387,6 +387,11 @@ func Load(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to load from environment: %w", err)
 	}
 
+	// Fold the deprecated [tailscale.agent] and [tailscale.monitor] sections
+	// into the unified fields. Runs last so it sees both file and env values,
+	// and only fills settings the user left unset.
+	cfg.Tailscale = cfg.Tailscale.MigrateFromOldFormat()
+
 	return cfg, nil
 }
 

--- a/internal/config/tailscale_config_test.go
+++ b/internal/config/tailscale_config_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,7 @@ func TestTailscaleConfig_AutoDetection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			method, err := tt.config.GetEffectiveMethod()
-			
+
 			if tt.expectError {
 				require.Error(t, err, "expected error but got none")
 				if tt.errorContains != "" {
@@ -170,7 +171,7 @@ func TestTailscaleConfig_Validation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.config.Validate()
-			
+
 			if tt.expectError {
 				require.Error(t, err, "expected error but got none")
 				if tt.errorContains != "" {
@@ -263,16 +264,16 @@ func TestTailscaleConfig_EnvironmentOverrides(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear env
 			os.Clearenv()
-			
+
 			// Set test env vars
 			for k, v := range tt.envVars {
 				os.Setenv(k, v)
 			}
-			
+
 			// Apply env overrides
 			cfg := tt.initial
 			cfg.loadFromEnv()
-			
+
 			// Compare
 			assert.Equal(t, tt.expected.Enabled, cfg.Enabled, "Enabled field mismatch")
 			assert.Equal(t, tt.expected.Method, cfg.Method, "Method field mismatch")
@@ -377,7 +378,7 @@ func TestTailscaleConfig_BackwardCompatibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			migrated := tt.oldStyle.Tailscale.MigrateFromOldFormat()
-			
+
 			assert.Equal(t, tt.expected.Enabled, migrated.Enabled, "Enabled field mismatch")
 			assert.Equal(t, tt.expected.Method, migrated.Method, "Method field mismatch")
 			assert.Equal(t, tt.expected.AuthKey, migrated.AuthKey, "AuthKey field mismatch")
@@ -480,4 +481,30 @@ func splitEnvPair(env string) []string {
 		}
 	}
 	return []string{env, ""}
+}
+// Load must fold the deprecated [tailscale.monitor] section into the unified
+// fields. Before this was wired up, MigrateFromOldFormat existed but was never
+// called, so these settings were silently dropped in favour of the defaults.
+func TestLoad_MigratesDeprecatedTailscaleSection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	require.NoError(t, os.WriteFile(path, []byte(`
+[tailscale]
+enabled = true
+
+[tailscale.monitor]
+discovery_prefix = "netronome-agent"
+`), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "netronome-agent", cfg.Tailscale.DiscoveryPrefix,
+		"deprecated [tailscale.monitor] discovery_prefix should reach the unified field")
+
+	// Values the user did not set must keep their defaults, not be zeroed.
+	assert.Equal(t, "5m", cfg.Tailscale.DiscoveryInterval)
+	assert.Equal(t, 8200, cfg.Tailscale.DiscoveryPort)
+	assert.True(t, cfg.Tailscale.AutoDiscover)
 }


### PR DESCRIPTION
`MigrateFromOldFormat` has existed since the Tailscale integration landed in #71, but nothing outside its own test ever called it. The deprecated `[tailscale.agent]` and `[tailscale.monitor]` sections were being parsed and then silently dropped, so anyone setting `discovery_prefix` there quietly got the default instead. This calls it at the end of `Load`, after both the file decode and the env overrides, so it sees final values.

The change is safe by construction: every branch in that function only fills a field the user left unset, so it can't override an explicit setting. Worth being honest about the size of the win, though — defaults pre-fill most of the unified fields, so `discovery_prefix` is the only setting this actually rescues and the rest of the function stays inert. The added test exercises the path through `Load` and fails if the call is removed.

Found while auditing dead code in #252, which is where the deprecated `accept_routes` field turned out to be unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy Tailscale configuration sections.
  * Legacy monitor and agent settings are now automatically migrated into the unified Tailscale configuration.
  * Environment-variable overrides are preserved during migration, while unset values continue using appropriate defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->