### PR TITLE
fix(notifications): honor ntfy query params case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,8 @@ Configure notifications through the web interface at **Settings > Notifications*
 - Gotify, Matrix, Ntfy, Webhook
 - [And 15+ more via Shoutrrr](https://containrrr.dev/shoutrrr/)
 
+ntfy URLs accept [Shoutrrr's ntfy query parameters](https://containrrr.dev/shoutrrr/v0.8/services/ntfy/#query-param-props) — `title`, `priority`, `tags`, `actions`, `click`, `attach`, `filename`, `delay` (aka `at`/`in`), `email`, `icon`, `cache` and `firebase`. Add `?scheme=http` for a self-hosted server without TLS; the default is `https`. Parameters Netronome cannot make sense of are logged and ignored, never fatal.
+
 #### Notification Events
 
 - Speed test completion, failures, threshold breaches

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -151,7 +151,7 @@ func (n *Notifier) SendNotification(category, eventType string, message string, 
 			var sendErr error
 
 			if isNtfyURL(rule.Channel.URL) {
-				sendErr = sendNtfy(rule.Channel.URL, message)
+				sendErr = sendNtfy(rule.Channel.URL, notificationTitle(category), message)
 			} else {
 				tempNotifier, err := shoutrrr.CreateSender(rule.Channel.URL)
 				if err != nil {
@@ -393,7 +393,7 @@ func (n *Notifier) sendDirect(message string) error {
 	var errs []error
 
 	for _, ntfyURL := range n.ntfyURLs {
-		if err := sendNtfy(ntfyURL, message); err != nil {
+		if err := sendNtfy(ntfyURL, "Netronome", message); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/notifications/ntfy.go
+++ b/internal/notifications/ntfy.go
@@ -6,10 +6,16 @@ package notifications
 import (
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/ntfy"
+	"github.com/rs/zerolog/log"
 )
 
 // ntfyHTTPClient is a dedicated HTTP client for ntfy requests with a reasonable timeout.
@@ -17,57 +23,12 @@ var ntfyHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
-// ntfyConfig holds the parsed ntfy URL components. The fields mirror Shoutrrr's
-// ntfy service config so that URLs written for Shoutrrr behave the same here.
-type ntfyConfig struct {
-	apiURL   string
-	username string
-	password string
-
-	title    string
-	priority string
-	tags     []string
-	actions  []string
-	click    string
-	attach   string
-	filename string
-	delay    string
-	email    string
-	icon     string
-	cache    bool
-	firebase bool
-}
-
-// ntfyPriorities maps the priority values Shoutrrr accepts to their canonical
-// ntfy name. Shoutrrr matches the names case-insensitively and additionally
-// accepts the numeric values and "urgent" as aliases.
-var ntfyPriorities = map[string]string{
-	"min":     "min",
-	"low":     "low",
-	"default": "default",
-	"high":    "high",
-	"max":     "max",
-	"urgent":  "max",
-	"1":       "min",
-	"2":       "low",
-	"3":       "default",
-	"4":       "high",
-	"5":       "max",
-}
-
-// ntfyQueryKeys lists the query parameters Shoutrrr's ntfy service supports.
-// Keys are matched case-insensitively, matching Shoutrrr's PropKeyResolver, and
-// "at"/"in" are aliases for "delay".
-var ntfyQueryKeys = []string{
-	"actions", "at", "attach", "cache", "click", "delay", "email",
-	"filename", "firebase", "icon", "in", "priority", "scheme", "tags", "title",
-}
-
 // sendNtfy sends a notification directly to an ntfy server, bypassing Shoutrrr's
 // ntfy implementation which has a bug where it removes the Content-Type header,
 // causing newer ntfy servers to reject the plain-text body as invalid JSON.
-// title overrides any title set in the URL, mirroring how Shoutrrr lets send
-// params override the config.
+// Everything else is Shoutrrr's own config and request shape, so URLs written for
+// Shoutrrr behave the same here. title overrides any title set in the URL,
+// mirroring how Shoutrrr lets send params override the config.
 func sendNtfy(ntfyURL string, title string, message string) error {
 	cfg, err := parseNtfyURL(ntfyURL)
 	if err != nil {
@@ -75,36 +36,42 @@ func sendNtfy(ntfyURL string, title string, message string) error {
 	}
 
 	if title != "" {
-		cfg.title = title
+		cfg.Title = title
 	}
 
-	req, err := http.NewRequest(http.MethodPost, cfg.apiURL, strings.NewReader(message))
+	// Not cfg.GetAPIURL(): that embeds the credentials in the URL, where they can
+	// leak into logged errors. Same endpoint, credentials sent as a header instead.
+	apiURL := url.URL{Scheme: cfg.Scheme, Host: cfg.Host, Path: "/" + cfg.Topic}
+
+	req, err := http.NewRequest(http.MethodPost, apiURL.String(), strings.NewReader(message))
 	if err != nil {
 		return fmt.Errorf("failed to create ntfy request: %w", err)
 	}
 
+	if cfg.Username != "" || cfg.Password != "" {
+		req.SetBasicAuth(cfg.Username, cfg.Password)
+	}
+
+	// The one thing Shoutrrr gets wrong, and the reason this file exists.
 	req.Header.Set("Content-Type", "text/plain")
 
-	setHeaderIfNotEmpty(req.Header, "Title", cfg.title)
-	setHeaderIfNotEmpty(req.Header, "Priority", cfg.priority)
-	setHeaderIfNotEmpty(req.Header, "Tags", strings.Join(cfg.tags, ","))
-	setHeaderIfNotEmpty(req.Header, "Delay", cfg.delay)
-	setHeaderIfNotEmpty(req.Header, "Actions", strings.Join(cfg.actions, ";"))
-	setHeaderIfNotEmpty(req.Header, "Click", cfg.click)
-	setHeaderIfNotEmpty(req.Header, "Attach", cfg.attach)
-	setHeaderIfNotEmpty(req.Header, "X-Icon", cfg.icon)
-	setHeaderIfNotEmpty(req.Header, "Filename", cfg.filename)
-	setHeaderIfNotEmpty(req.Header, "Email", cfg.email)
+	// Mirrors shoutrrr/pkg/services/ntfy.sendAPI.
+	setHeaderIfNotEmpty(req.Header, "Title", cfg.Title)
+	setHeaderIfNotEmpty(req.Header, "Priority", cfg.Priority.String())
+	setHeaderIfNotEmpty(req.Header, "Tags", strings.Join(cfg.Tags, ","))
+	setHeaderIfNotEmpty(req.Header, "Delay", cfg.Delay)
+	setHeaderIfNotEmpty(req.Header, "Actions", strings.Join(cfg.Actions, ";"))
+	setHeaderIfNotEmpty(req.Header, "Click", cfg.Click)
+	setHeaderIfNotEmpty(req.Header, "Attach", cfg.Attach)
+	setHeaderIfNotEmpty(req.Header, "X-Icon", cfg.Icon)
+	setHeaderIfNotEmpty(req.Header, "Filename", cfg.Filename)
+	setHeaderIfNotEmpty(req.Header, "Email", cfg.Email)
 
-	if !cfg.cache {
+	if !cfg.Cache {
 		req.Header.Set("Cache", "no")
 	}
-	if !cfg.firebase {
+	if !cfg.Firebase {
 		req.Header.Set("Firebase", "no")
-	}
-
-	if cfg.username != "" || cfg.password != "" {
-		req.SetBasicAuth(cfg.username, cfg.password)
 	}
 
 	resp, err := ntfyHTTPClient.Do(req)
@@ -122,9 +89,9 @@ func sendNtfy(ntfyURL string, title string, message string) error {
 }
 
 // parseNtfyURL converts a Shoutrrr ntfy URL (ntfy://[user:pass@]host/topic[?params])
-// into an ntfyConfig with the API endpoint URL, optional credentials and message
-// options.
-func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
+// into Shoutrrr's own ntfy config, so query keys, aliases, casing, defaults and
+// value parsing match Shoutrrr exactly.
+func parseNtfyURL(ntfyURL string) (*ntfy.Config, error) {
 	parsed, err := url.Parse(ntfyURL)
 	if err != nil {
 		return nil, err
@@ -139,110 +106,34 @@ func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
 		return nil, fmt.Errorf("ntfy URL must include a host")
 	}
 
+	cfg := &ntfy.Config{}
+	pkr := format.NewPropKeyResolver(cfg)
+	if err := pkr.SetDefaultProps(cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.Host = parsed.Host
+	cfg.Topic = topic
+	if parsed.User != nil {
+		cfg.Username = parsed.User.Username()
+		cfg.Password, _ = parsed.User.Password()
+	}
+
 	// Escape raw ";" so action separators survive query parsing, as Shoutrrr does.
 	parsed.RawQuery = strings.ReplaceAll(parsed.RawQuery, ";", "%3b")
-	query, err := url.ParseQuery(parsed.RawQuery)
-	if err != nil {
-		return nil, fmt.Errorf("invalid ntfy URL query: %w", err)
-	}
-
-	cfg := &ntfyConfig{
-		cache:    true,
-		firebase: true,
-	}
-
-	scheme := "https"
-
-	for key, vals := range query {
-		if len(vals) == 0 {
-			continue
-		}
-		value := vals[0]
-
-		// Shoutrrr resolves query keys case-insensitively, so "?Scheme=http"
-		// and "?scheme=http" are equivalent.
-		switch strings.ToLower(key) {
-		case "scheme":
-			switch strings.ToLower(value) {
-			case "http", "https":
-				scheme = strings.ToLower(value)
-			default:
-				return nil, fmt.Errorf("invalid ntfy scheme %q: accepted values are http or https", value)
-			}
-		case "title":
-			cfg.title = value
-		case "priority":
-			priority, ok := ntfyPriorities[strings.ToLower(value)]
-			if !ok {
-				return nil, fmt.Errorf("invalid ntfy priority %q: accepted values are 1-5, min, low, default, high, max or urgent", value)
-			}
-			cfg.priority = priority
-		case "tags":
-			cfg.tags = splitAndTrim(value, ",")
-		case "actions":
-			cfg.actions = splitAndTrim(value, ";")
-		case "click":
-			cfg.click = value
-		case "attach":
-			cfg.attach = value
-		case "filename":
-			cfg.filename = value
-		case "delay", "at", "in":
-			cfg.delay = value
-		case "email":
-			cfg.email = value
-		case "icon":
-			cfg.icon = value
-		case "cache":
-			cfg.cache, err = parseNtfyBool(key, value)
-			if err != nil {
-				return nil, err
-			}
-		case "firebase":
-			cfg.firebase, err = parseNtfyBool(key, value)
-			if err != nil {
-				return nil, err
-			}
-		default:
-			return nil, fmt.Errorf("%s is not a valid ntfy config key %v", key, ntfyQueryKeys)
+	query := parsed.Query()
+	// Sorted so colliding keys ("?scheme=http&Scheme=https", "?delay=…&at=…")
+	// resolve the same way on every send instead of by map order.
+	for _, key := range slices.Sorted(maps.Keys(query)) {
+		// A key we do not understand keeps its default rather than failing the
+		// whole channel — stored URLs predate this parsing and must keep working.
+		if err := pkr.Set(key, query[key][0]); err != nil {
+			log.Warn().Str("key", key).Err(err).Msg("ignoring ntfy URL option")
 		}
 	}
-
-	apiURL := &url.URL{
-		Scheme: scheme,
-		Host:   parsed.Host,
-		Path:   "/" + topic,
-	}
-	cfg.apiURL = apiURL.String()
-
-	if parsed.User != nil {
-		cfg.username = parsed.User.Username()
-		cfg.password, _ = parsed.User.Password()
-	}
+	cfg.Scheme = strings.ToLower(cfg.Scheme)
 
 	return cfg, nil
-}
-
-// parseNtfyBool parses the boolean values Shoutrrr accepts for config keys.
-func parseNtfyBool(key string, value string) (bool, error) {
-	switch strings.ToLower(value) {
-	case "1", "true", "yes":
-		return true, nil
-	case "0", "false", "no":
-		return false, nil
-	}
-	return false, fmt.Errorf("invalid value %q for ntfy %s: accepted values are 1, true, yes or 0, false, no", value, strings.ToLower(key))
-}
-
-// splitAndTrim splits a separated list value and drops empty entries.
-func splitAndTrim(value string, sep string) []string {
-	var out []string
-	for _, part := range strings.Split(value, sep) {
-		if part = strings.TrimSpace(part); part != "" {
-			out = append(out, part)
-		}
-	}
-	return out
 }
 
 func setHeaderIfNotEmpty(headers http.Header, key string, value string) {

--- a/internal/notifications/ntfy.go
+++ b/internal/notifications/ntfy.go
@@ -17,20 +17,65 @@ var ntfyHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
-// ntfyConfig holds the parsed ntfy URL components.
+// ntfyConfig holds the parsed ntfy URL components. The fields mirror Shoutrrr's
+// ntfy service config so that URLs written for Shoutrrr behave the same here.
 type ntfyConfig struct {
 	apiURL   string
 	username string
 	password string
+
+	title    string
+	priority string
+	tags     []string
+	actions  []string
+	click    string
+	attach   string
+	filename string
+	delay    string
+	email    string
+	icon     string
+	cache    bool
+	firebase bool
+}
+
+// ntfyPriorities maps the priority values Shoutrrr accepts to their canonical
+// ntfy name. Shoutrrr matches the names case-insensitively and additionally
+// accepts the numeric values and "urgent" as aliases.
+var ntfyPriorities = map[string]string{
+	"min":     "min",
+	"low":     "low",
+	"default": "default",
+	"high":    "high",
+	"max":     "max",
+	"urgent":  "max",
+	"1":       "min",
+	"2":       "low",
+	"3":       "default",
+	"4":       "high",
+	"5":       "max",
+}
+
+// ntfyQueryKeys lists the query parameters Shoutrrr's ntfy service supports.
+// Keys are matched case-insensitively, matching Shoutrrr's PropKeyResolver, and
+// "at"/"in" are aliases for "delay".
+var ntfyQueryKeys = []string{
+	"actions", "at", "attach", "cache", "click", "delay", "email",
+	"filename", "firebase", "icon", "in", "priority", "scheme", "tags", "title",
 }
 
 // sendNtfy sends a notification directly to an ntfy server, bypassing Shoutrrr's
 // ntfy implementation which has a bug where it removes the Content-Type header,
 // causing newer ntfy servers to reject the plain-text body as invalid JSON.
-func sendNtfy(ntfyURL string, message string) error {
+// title overrides any title set in the URL, mirroring how Shoutrrr lets send
+// params override the config.
+func sendNtfy(ntfyURL string, title string, message string) error {
 	cfg, err := parseNtfyURL(ntfyURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse ntfy URL: %w", err)
+	}
+
+	if title != "" {
+		cfg.title = title
 	}
 
 	req, err := http.NewRequest(http.MethodPost, cfg.apiURL, strings.NewReader(message))
@@ -39,6 +84,24 @@ func sendNtfy(ntfyURL string, message string) error {
 	}
 
 	req.Header.Set("Content-Type", "text/plain")
+
+	setHeaderIfNotEmpty(req.Header, "Title", cfg.title)
+	setHeaderIfNotEmpty(req.Header, "Priority", cfg.priority)
+	setHeaderIfNotEmpty(req.Header, "Tags", strings.Join(cfg.tags, ","))
+	setHeaderIfNotEmpty(req.Header, "Delay", cfg.delay)
+	setHeaderIfNotEmpty(req.Header, "Actions", strings.Join(cfg.actions, ";"))
+	setHeaderIfNotEmpty(req.Header, "Click", cfg.click)
+	setHeaderIfNotEmpty(req.Header, "Attach", cfg.attach)
+	setHeaderIfNotEmpty(req.Header, "X-Icon", cfg.icon)
+	setHeaderIfNotEmpty(req.Header, "Filename", cfg.filename)
+	setHeaderIfNotEmpty(req.Header, "Email", cfg.email)
+
+	if !cfg.cache {
+		req.Header.Set("Cache", "no")
+	}
+	if !cfg.firebase {
+		req.Header.Set("Firebase", "no")
+	}
 
 	if cfg.username != "" || cfg.password != "" {
 		req.SetBasicAuth(cfg.username, cfg.password)
@@ -59,7 +122,8 @@ func sendNtfy(ntfyURL string, message string) error {
 }
 
 // parseNtfyURL converts a Shoutrrr ntfy URL (ntfy://[user:pass@]host/topic[?params])
-// into an ntfyConfig with the API endpoint URL and optional credentials.
+// into an ntfyConfig with the API endpoint URL, optional credentials and message
+// options.
 func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
 	parsed, err := url.Parse(ntfyURL)
 	if err != nil {
@@ -75,9 +139,73 @@ func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
 		return nil, fmt.Errorf("ntfy URL must include a host")
 	}
 
+	// Escape raw ";" so action separators survive query parsing, as Shoutrrr does.
+	parsed.RawQuery = strings.ReplaceAll(parsed.RawQuery, ";", "%3b")
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ntfy URL query: %w", err)
+	}
+
+	cfg := &ntfyConfig{
+		cache:    true,
+		firebase: true,
+	}
+
 	scheme := "https"
-	if q := parsed.Query(); q.Get("scheme") == "http" {
-		scheme = "http"
+
+	for key, vals := range query {
+		if len(vals) == 0 {
+			continue
+		}
+		value := vals[0]
+
+		// Shoutrrr resolves query keys case-insensitively, so "?Scheme=http"
+		// and "?scheme=http" are equivalent.
+		switch strings.ToLower(key) {
+		case "scheme":
+			switch strings.ToLower(value) {
+			case "http", "https":
+				scheme = strings.ToLower(value)
+			default:
+				return nil, fmt.Errorf("invalid ntfy scheme %q: accepted values are http or https", value)
+			}
+		case "title":
+			cfg.title = value
+		case "priority":
+			priority, ok := ntfyPriorities[strings.ToLower(value)]
+			if !ok {
+				return nil, fmt.Errorf("invalid ntfy priority %q: accepted values are 1-5, min, low, default, high, max or urgent", value)
+			}
+			cfg.priority = priority
+		case "tags":
+			cfg.tags = splitAndTrim(value, ",")
+		case "actions":
+			cfg.actions = splitAndTrim(value, ";")
+		case "click":
+			cfg.click = value
+		case "attach":
+			cfg.attach = value
+		case "filename":
+			cfg.filename = value
+		case "delay", "at", "in":
+			cfg.delay = value
+		case "email":
+			cfg.email = value
+		case "icon":
+			cfg.icon = value
+		case "cache":
+			cfg.cache, err = parseNtfyBool(key, value)
+			if err != nil {
+				return nil, err
+			}
+		case "firebase":
+			cfg.firebase, err = parseNtfyBool(key, value)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("%s is not a valid ntfy config key %v", key, ntfyQueryKeys)
+		}
 	}
 
 	apiURL := &url.URL{
@@ -85,10 +213,7 @@ func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
 		Host:   parsed.Host,
 		Path:   "/" + topic,
 	}
-
-	cfg := &ntfyConfig{
-		apiURL: apiURL.String(),
-	}
+	cfg.apiURL = apiURL.String()
 
 	if parsed.User != nil {
 		cfg.username = parsed.User.Username()
@@ -96,6 +221,34 @@ func parseNtfyURL(ntfyURL string) (*ntfyConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// parseNtfyBool parses the boolean values Shoutrrr accepts for config keys.
+func parseNtfyBool(key string, value string) (bool, error) {
+	switch strings.ToLower(value) {
+	case "1", "true", "yes":
+		return true, nil
+	case "0", "false", "no":
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid value %q for ntfy %s: accepted values are 1, true, yes or 0, false, no", value, strings.ToLower(key))
+}
+
+// splitAndTrim splits a separated list value and drops empty entries.
+func splitAndTrim(value string, sep string) []string {
+	var out []string
+	for _, part := range strings.Split(value, sep) {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func setHeaderIfNotEmpty(headers http.Header, key string, value string) {
+	if value != "" {
+		headers.Set(key, value)
+	}
 }
 
 // isNtfyURL checks whether a notification URL uses the ntfy scheme.

--- a/internal/notifications/ntfy_test.go
+++ b/internal/notifications/ntfy_test.go
@@ -20,7 +20,7 @@ func TestParseNtfyURL(t *testing.T) {
 		wantURL  string
 		wantUser string
 		wantPass string
-		wantErr  bool
+		wantErr  string
 	}{
 		{
 			name:    "simple host and topic",
@@ -40,9 +40,33 @@ func TestParseNtfyURL(t *testing.T) {
 			wantPass: "pass",
 		},
 		{
+			name:     "access token as password",
+			input:    "ntfy://:tk_token@ntfy/htpc",
+			wantURL:  "https://ntfy/htpc",
+			wantPass: "tk_token",
+		},
+		{
 			name:    "with scheme override to http",
 			input:   "ntfy://ntfy.local/test?scheme=http",
 			wantURL: "http://ntfy.local/test",
+		},
+		{
+			// Shoutrrr resolves query keys case-insensitively.
+			name:    "scheme query key is case insensitive",
+			input:   "ntfy://:tk_token@ntfy/htpc?Scheme=http",
+			wantURL: "http://ntfy/htpc",
+
+			wantPass: "tk_token",
+		},
+		{
+			name:    "scheme value is case insensitive",
+			input:   "ntfy://ntfy.local/test?scheme=HTTP",
+			wantURL: "http://ntfy.local/test",
+		},
+		{
+			name:    "explicit https scheme",
+			input:   "ntfy://ntfy.example.com/alerts?scheme=https",
+			wantURL: "https://ntfy.example.com/alerts",
 		},
 		{
 			name:    "tailscale host",
@@ -52,25 +76,46 @@ func TestParseNtfyURL(t *testing.T) {
 		{
 			name:    "missing topic",
 			input:   "ntfy://ntfy.example.com",
-			wantErr: true,
+			wantErr: "must include a topic",
 		},
 		{
 			name:    "empty path",
 			input:   "ntfy://ntfy.example.com/",
-			wantErr: true,
+			wantErr: "must include a topic",
 		},
 		{
 			name:    "missing host with topic",
 			input:   "ntfy:///alerts",
-			wantErr: true,
+			wantErr: "must include a host",
+		},
+		{
+			name:    "invalid scheme",
+			input:   "ntfy://ntfy.example.com/alerts?scheme=ftp",
+			wantErr: "invalid ntfy scheme",
+		},
+		{
+			name:    "invalid priority",
+			input:   "ntfy://ntfy.example.com/alerts?priority=critical",
+			wantErr: "invalid ntfy priority",
+		},
+		{
+			name:    "invalid bool",
+			input:   "ntfy://ntfy.example.com/alerts?cache=maybe",
+			wantErr: "accepted values are 1, true, yes or 0, false, no",
+		},
+		{
+			name:    "unknown query key",
+			input:   "ntfy://ntfy.example.com/alerts?bogus=1",
+			wantErr: "bogus is not a valid ntfy config key",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := parseNtfyURL(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
@@ -79,6 +124,59 @@ func TestParseNtfyURL(t *testing.T) {
 			assert.Equal(t, tt.wantPass, cfg.password)
 		})
 	}
+}
+
+func TestParseNtfyURLOptions(t *testing.T) {
+	t.Run("parses message options", func(t *testing.T) {
+		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?title=Hi&priority=high&tags=warning,skull&click=https://example.com&attach=https://example.com/a.png&filename=a.png&email=me@example.com&icon=https://example.com/i.png&cache=no&firebase=no&delay=30min")
+		require.NoError(t, err)
+
+		assert.Equal(t, "Hi", cfg.title)
+		assert.Equal(t, "high", cfg.priority)
+		assert.Equal(t, []string{"warning", "skull"}, cfg.tags)
+		assert.Equal(t, "https://example.com", cfg.click)
+		assert.Equal(t, "https://example.com/a.png", cfg.attach)
+		assert.Equal(t, "a.png", cfg.filename)
+		assert.Equal(t, "me@example.com", cfg.email)
+		assert.Equal(t, "https://example.com/i.png", cfg.icon)
+		assert.False(t, cfg.cache)
+		assert.False(t, cfg.firebase)
+		assert.Equal(t, "30min", cfg.delay)
+	})
+
+	t.Run("cache and firebase default to enabled", func(t *testing.T) {
+		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts")
+		require.NoError(t, err)
+
+		assert.True(t, cfg.cache)
+		assert.True(t, cfg.firebase)
+		assert.Empty(t, cfg.priority)
+	})
+
+	t.Run("normalizes numeric and alias priorities", func(t *testing.T) {
+		for value, want := range map[string]string{
+			"1": "min", "2": "low", "3": "default", "4": "high", "5": "max",
+			"urgent": "max", "Max": "max", "MIN": "min",
+		} {
+			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?priority=" + value)
+			require.NoError(t, err, value)
+			assert.Equal(t, want, cfg.priority, value)
+		}
+	})
+
+	t.Run("delay accepts at and in aliases", func(t *testing.T) {
+		for _, key := range []string{"delay", "at", "in", "At", "IN"} {
+			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?" + key + "=tomorrow")
+			require.NoError(t, err, key)
+			assert.Equal(t, "tomorrow", cfg.delay, key)
+		}
+	})
+
+	t.Run("actions are separated by semicolons", func(t *testing.T) {
+		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?actions=view, Open, https://example.com; http, Ack, https://example.com/ack")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"view, Open, https://example.com", "http, Ack, https://example.com/ack"}, cfg.actions)
+	})
 }
 
 func TestIsNtfyURL(t *testing.T) {
@@ -104,7 +202,7 @@ func TestSendNtfy(t *testing.T) {
 		defer server.Close()
 
 		ntfyURL := "ntfy://" + server.Listener.Addr().String() + "/test-topic?scheme=http"
-		err := sendNtfy(ntfyURL, "Hello from Netronome")
+		err := sendNtfy(ntfyURL, "Netronome", "Hello from Netronome")
 
 		require.NoError(t, err)
 		assert.Equal(t, "text/plain", receivedContentType)
@@ -119,7 +217,7 @@ func TestSendNtfy(t *testing.T) {
 		defer server.Close()
 
 		ntfyURL := "ntfy://" + server.Listener.Addr().String() + "/test-topic?scheme=http"
-		err := sendNtfy(ntfyURL, "test message")
+		err := sendNtfy(ntfyURL, "Netronome", "test message")
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "400")
@@ -137,10 +235,89 @@ func TestSendNtfy(t *testing.T) {
 		defer server.Close()
 
 		ntfyURL := "ntfy://myuser:mypass@" + server.Listener.Addr().String() + "/alerts?scheme=http"
-		err := sendNtfy(ntfyURL, "authenticated message")
+		err := sendNtfy(ntfyURL, "Netronome", "authenticated message")
 
 		require.NoError(t, err)
 		assert.Equal(t, "myuser", receivedUser)
 		assert.Equal(t, "mypass", receivedPass)
+	})
+
+	t.Run("passes an access token as the basic auth password", func(t *testing.T) {
+		var receivedUser string
+		var receivedPass string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedUser, receivedPass, _ = r.BasicAuth()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ntfyURL := "ntfy://:tk_token@" + server.Listener.Addr().String() + "/alerts?Scheme=http"
+		err := sendNtfy(ntfyURL, "Netronome", "token message")
+
+		require.NoError(t, err)
+		assert.Empty(t, receivedUser)
+		assert.Equal(t, "tk_token", receivedPass)
+	})
+
+	t.Run("sends message option headers", func(t *testing.T) {
+		var received http.Header
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			received = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ntfyURL := "ntfy://" + server.Listener.Addr().String() + "/alerts?scheme=http&priority=5&tags=warning,skull&click=https://example.com&icon=https://example.com/i.png&filename=a.png&email=me@example.com&cache=no&firebase=no&delay=30min"
+		err := sendNtfy(ntfyURL, "Netronome: Speedtest", "message")
+
+		require.NoError(t, err)
+		assert.Equal(t, "Netronome: Speedtest", received.Get("Title"))
+		assert.Equal(t, "max", received.Get("Priority"))
+		assert.Equal(t, "warning,skull", received.Get("Tags"))
+		assert.Equal(t, "https://example.com", received.Get("Click"))
+		assert.Equal(t, "https://example.com/i.png", received.Get("X-Icon"))
+		assert.Equal(t, "a.png", received.Get("Filename"))
+		assert.Equal(t, "me@example.com", received.Get("Email"))
+		assert.Equal(t, "30min", received.Get("Delay"))
+		assert.Equal(t, "no", received.Get("Cache"))
+		assert.Equal(t, "no", received.Get("Firebase"))
+	})
+
+	t.Run("omits optional headers when unset", func(t *testing.T) {
+		var received http.Header
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			received = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ntfyURL := "ntfy://" + server.Listener.Addr().String() + "/alerts?scheme=http"
+		err := sendNtfy(ntfyURL, "", "message")
+
+		require.NoError(t, err)
+		for _, key := range []string{"Title", "Priority", "Tags", "Delay", "Actions", "Click", "Attach", "X-Icon", "Filename", "Email", "Cache", "Firebase"} {
+			assert.Empty(t, received.Get(key), key)
+		}
+	})
+
+	t.Run("caller title overrides the url title", func(t *testing.T) {
+		var received http.Header
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			received = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ntfyURL := "ntfy://" + server.Listener.Addr().String() + "/alerts?scheme=http&title=FromURL"
+
+		require.NoError(t, sendNtfy(ntfyURL, "FromCaller", "message"))
+		assert.Equal(t, "FromCaller", received.Get("Title"))
+
+		require.NoError(t, sendNtfy(ntfyURL, "", "message"))
+		assert.Equal(t, "FromURL", received.Get("Title"))
 	})
 }

--- a/internal/notifications/ntfy_test.go
+++ b/internal/notifications/ntfy_test.go
@@ -52,10 +52,9 @@ func TestParseNtfyURL(t *testing.T) {
 		},
 		{
 			// Shoutrrr resolves query keys case-insensitively.
-			name:    "scheme query key is case insensitive",
-			input:   "ntfy://:tk_token@ntfy/htpc?Scheme=http",
-			wantURL: "http://ntfy/htpc",
-
+			name:     "scheme query key is case insensitive",
+			input:    "ntfy://:tk_token@ntfy/htpc?Scheme=http",
+			wantURL:  "http://ntfy/htpc",
 			wantPass: "tk_token",
 		},
 		{
@@ -89,24 +88,11 @@ func TestParseNtfyURL(t *testing.T) {
 			wantErr: "must include a host",
 		},
 		{
-			name:    "invalid scheme",
-			input:   "ntfy://ntfy.example.com/alerts?scheme=ftp",
-			wantErr: "invalid ntfy scheme",
-		},
-		{
-			name:    "invalid priority",
-			input:   "ntfy://ntfy.example.com/alerts?priority=critical",
-			wantErr: "invalid ntfy priority",
-		},
-		{
-			name:    "invalid bool",
-			input:   "ntfy://ntfy.example.com/alerts?cache=maybe",
-			wantErr: "accepted values are 1, true, yes or 0, false, no",
-		},
-		{
-			name:    "unknown query key",
-			input:   "ntfy://ntfy.example.com/alerts?bogus=1",
-			wantErr: "bogus is not a valid ntfy config key",
+			// Options we cannot make sense of keep their default rather than
+			// failing the channel, so a stored URL never stops delivering.
+			name:    "unusable options fall back to defaults",
+			input:   "ntfy://ntfy.example.com/alerts?bogus=1&priority=critical&cache=maybe&title=100%off",
+			wantURL: "https://ntfy.example.com/alerts",
 		},
 	}
 
@@ -119,9 +105,9 @@ func TestParseNtfyURL(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantURL, cfg.apiURL)
-			assert.Equal(t, tt.wantUser, cfg.username)
-			assert.Equal(t, tt.wantPass, cfg.password)
+			assert.Equal(t, tt.wantURL, cfg.Scheme+"://"+cfg.Host+"/"+cfg.Topic)
+			assert.Equal(t, tt.wantUser, cfg.Username)
+			assert.Equal(t, tt.wantPass, cfg.Password)
 		})
 	}
 }
@@ -131,36 +117,55 @@ func TestParseNtfyURLOptions(t *testing.T) {
 		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?title=Hi&priority=high&tags=warning,skull&click=https://example.com&attach=https://example.com/a.png&filename=a.png&email=me@example.com&icon=https://example.com/i.png&cache=no&firebase=no&delay=30min")
 		require.NoError(t, err)
 
-		assert.Equal(t, "Hi", cfg.title)
-		assert.Equal(t, "high", cfg.priority)
-		assert.Equal(t, []string{"warning", "skull"}, cfg.tags)
-		assert.Equal(t, "https://example.com", cfg.click)
-		assert.Equal(t, "https://example.com/a.png", cfg.attach)
-		assert.Equal(t, "a.png", cfg.filename)
-		assert.Equal(t, "me@example.com", cfg.email)
-		assert.Equal(t, "https://example.com/i.png", cfg.icon)
-		assert.False(t, cfg.cache)
-		assert.False(t, cfg.firebase)
-		assert.Equal(t, "30min", cfg.delay)
+		assert.Equal(t, "Hi", cfg.Title)
+		assert.Equal(t, "High", cfg.Priority.String())
+		assert.Equal(t, []string{"warning", "skull"}, cfg.Tags)
+		assert.Equal(t, "https://example.com", cfg.Click)
+		assert.Equal(t, "https://example.com/a.png", cfg.Attach)
+		assert.Equal(t, "a.png", cfg.Filename)
+		assert.Equal(t, "me@example.com", cfg.Email)
+		assert.Equal(t, "https://example.com/i.png", cfg.Icon)
+		assert.False(t, cfg.Cache)
+		assert.False(t, cfg.Firebase)
+		assert.Equal(t, "30min", cfg.Delay)
 	})
 
 	t.Run("cache and firebase default to enabled", func(t *testing.T) {
 		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts")
 		require.NoError(t, err)
 
-		assert.True(t, cfg.cache)
-		assert.True(t, cfg.firebase)
-		assert.Empty(t, cfg.priority)
+		assert.True(t, cfg.Cache)
+		assert.True(t, cfg.Firebase)
+		assert.Equal(t, "Default", cfg.Priority.String())
 	})
 
 	t.Run("normalizes numeric and alias priorities", func(t *testing.T) {
 		for value, want := range map[string]string{
-			"1": "min", "2": "low", "3": "default", "4": "high", "5": "max",
-			"urgent": "max", "Max": "max", "MIN": "min",
+			"1": "Min", "2": "Low", "3": "Default", "4": "High", "5": "Max",
+			"Max": "Max", "MIN": "Min",
 		} {
 			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?priority=" + value)
 			require.NoError(t, err, value)
-			assert.Equal(t, want, cfg.priority, value)
+			assert.Equal(t, want, cfg.Priority.String(), value)
+		}
+	})
+
+	t.Run("boolean options accept shoutrrr's aliases", func(t *testing.T) {
+		for _, value := range []string{"no", "n", "0", "false"} {
+			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?cache=" + value)
+			require.NoError(t, err, value)
+			assert.False(t, cfg.Cache, value)
+		}
+	})
+
+	t.Run("colliding keys resolve the same way every time", func(t *testing.T) {
+		for range 20 {
+			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?Scheme=https&scheme=http&delay=a&at=b")
+			require.NoError(t, err)
+			// Keys are applied in sorted order, so the later one wins: "scheme"
+			// after "Scheme", "delay" after "at".
+			assert.Equal(t, "http", cfg.Scheme)
+			assert.Equal(t, "a", cfg.Delay)
 		}
 	})
 
@@ -168,14 +173,16 @@ func TestParseNtfyURLOptions(t *testing.T) {
 		for _, key := range []string{"delay", "at", "in", "At", "IN"} {
 			cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?" + key + "=tomorrow")
 			require.NoError(t, err, key)
-			assert.Equal(t, "tomorrow", cfg.delay, key)
+			assert.Equal(t, "tomorrow", cfg.Delay, key)
 		}
 	})
 
 	t.Run("actions are separated by semicolons", func(t *testing.T) {
 		cfg, err := parseNtfyURL("ntfy://ntfy.example.com/alerts?actions=view, Open, https://example.com; http, Ack, https://example.com/ack")
 		require.NoError(t, err)
-		assert.Equal(t, []string{"view, Open, https://example.com", "http, Ack, https://example.com/ack"}, cfg.actions)
+		require.Len(t, cfg.Actions, 2)
+		assert.Contains(t, cfg.Actions[0], "view")
+		assert.Contains(t, cfg.Actions[1], "http")
 	})
 }
 
@@ -274,7 +281,7 @@ func TestSendNtfy(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "Netronome: Speedtest", received.Get("Title"))
-		assert.Equal(t, "max", received.Get("Priority"))
+		assert.Equal(t, "Max", received.Get("Priority"))
 		assert.Equal(t, "warning,skull", received.Get("Tags"))
 		assert.Equal(t, "https://example.com", received.Get("Click"))
 		assert.Equal(t, "https://example.com/i.png", received.Get("X-Icon"))
@@ -298,9 +305,11 @@ func TestSendNtfy(t *testing.T) {
 		err := sendNtfy(ntfyURL, "", "message")
 
 		require.NoError(t, err)
-		for _, key := range []string{"Title", "Priority", "Tags", "Delay", "Actions", "Click", "Attach", "X-Icon", "Filename", "Email", "Cache", "Firebase"} {
+		for _, key := range []string{"Title", "Tags", "Delay", "Actions", "Click", "Attach", "X-Icon", "Filename", "Email", "Cache", "Firebase"} {
 			assert.Empty(t, received.Get(key), key)
 		}
+		// Shoutrrr always sends a priority, defaulting to "Default".
+		assert.Equal(t, "Default", received.Get("Priority"))
 	})
 
 	t.Run("caller title overrides the url title", func(t *testing.T) {

--- a/internal/notifications/validate_test.go
+++ b/internal/notifications/validate_test.go
@@ -41,11 +41,6 @@ func TestValidateNotificationURL(t *testing.T) {
 			rawURL: "ntfy://:tk_token@ntfy/htpc?Scheme=http",
 		},
 		{
-			name:    "ntfy unknown query key",
-			rawURL:  "ntfy://ntfy/htpc?Schema=http",
-			wantErr: "not a valid ntfy config key",
-		},
-		{
 			name:    "trims whitespace before validating",
 			rawURL:  "  pushover://API_TOKEN@USER_KEY  ",
 			wantErr: "token missing",

--- a/internal/notifications/validate_test.go
+++ b/internal/notifications/validate_test.go
@@ -37,6 +37,15 @@ func TestValidateNotificationURL(t *testing.T) {
 			wantErr: "must include a host",
 		},
 		{
+			name:   "ntfy scheme override with shoutrrr casing",
+			rawURL: "ntfy://:tk_token@ntfy/htpc?Scheme=http",
+		},
+		{
+			name:    "ntfy unknown query key",
+			rawURL:  "ntfy://ntfy/htpc?Schema=http",
+			wantErr: "not a valid ntfy config key",
+		},
+		{
 			name:    "trims whitespace before validating",
 			rawURL:  "  pushover://API_TOKEN@USER_KEY  ",
 			wantErr: "token missing",

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -233,7 +233,8 @@ export const SHOUTRRR_SERVICES = [
   { value: "join", label: "Join", example: "join://APIKEY@DEVICE/?icon=URL&title=TITLE" },
   { value: "mattermost", label: "Mattermost", example: "mattermost://HOSTNAME/TOKEN" },
   { value: "matrix", label: "Matrix", example: "matrix://USERNAME:PASSWORD@HOSTNAME:PORT/ROOM" },
-  { value: "ntfy", label: "ntfy", example: "ntfy://[USER:PASS@]HOSTNAME/topic" },
+  // ntfy defaults to https; add ?scheme=http for plain-HTTP servers.
+  { value: "ntfy", label: "ntfy", example: "ntfy://[USER:PASS@]HOSTNAME/topic[?scheme=http]" },
   { value: "opsgenie", label: "OpsGenie", example: "opsgenie://APIKEY" },
   { value: "pushbullet", label: "Pushbullet", example: "pushbullet://APIKEY" },
   // Pushover token is the URL "password" per Shoutrrr's format.


### PR DESCRIPTION
## Summary

`ntfy://:tk_token@ntfy/htpc?Scheme=http` connected on port 443 instead of 80. Netronome does not route ntfy through Shoutrrr — `internal/notifications/ntfy.go` reimplements it to work around Shoutrrr deleting the `Content-Type` header, which newer ntfy servers reject — and that hand-rolled parser read the scheme with an exact lowercase key (`q.Get("scheme")`). Shoutrrr lowercases every query key before resolving it, so capital-`S` is valid there and fell through to the `https` default here. The same casing gap meant every other prop was ignored outright. Closes #255.

Rather than fix the one key, `parseNtfyURL` now hands the query to Shoutrrr's own `ntfy.Config` and `format.PropKeyResolver` — both exported, and Shoutrrr is already in `go.mod`. That gets case-insensitive keys, the `at`/`in` aliases, priority and boolean parsing, and the full set of message option headers (`Title`, `Priority`, `Tags`, `Delay`, `Actions`, `Click`, `Attach`, `X-Icon`, `Filename`, `Email`, `Cache`, `Firebase`) without maintaining a second copy of Shoutrrr's key list. Options that cannot be resolved are logged and ignored rather than rejected — a stored URL like `?scheme=http&markdown=yes` delivered fine before this PR, and rejecting it would both stop notifications and make the channel impossible to toggle off, since the UI resends the stored URL on update. Keys are applied in sorted order so `?Scheme=`/`?scheme=` and `?at=`/`?delay=` collisions resolve the same way on every send. Titles now pass through (`Netronome: Speedtest` etc.), matching the params the Shoutrrr router path already sends, and access tokens in the `:tk_token@host` form keep working since Go converts URL userinfo to Basic auth — ntfy's `-u :tk_...` convention.

## Testing

`go test ./internal/notifications/`, `go vet ./internal/notifications/`, `gofmt -l`, `go build ./...` — all clean. Verified end to end by running the server against a local plain-HTTP ntfy endpoint and against ntfy.sh: `?Scheme=http` delivers (and fails on `develop` with the reported TLS error), option headers reach the wire, a channel stored before this change with an unknown query key still sends and still toggles, and the rule-based path delivers with its category title.

Frontend commands not run — the only web change is the ntfy example string in the channel form: `ntfy://[USER:PASS@]HOSTNAME/topic[?scheme=http]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced ntfy notifications to support a configurable notification title (including overrides) and richer ntfy options via URL query parameters (e.g., priority, tags, actions, links, attachments, icons, delay, email).
  * Improved ntfy URL handling for scheme selection (including `?scheme=http`), access tokens, and priority aliases.

* **Bug Fixes**
  * ntfy requests now include the notification title consistently.

* **Documentation**
  * Updated ntfy URL examples and README to document plaintext HTTP usage and supported parameters.

* **Tests**
  * Expanded ntfy URL parsing and ntfy sending test coverage, including header validation and scheme override cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
