### PR TITLE
feat(updates): add in-app release notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ All configuration options can be set via environment variables using the `NETRON
 NETRONOME__HOST=0.0.0.0              # Listen address
 NETRONOME__PORT=7575                 # Web UI port
 NETRONOME__BASE_URL=/                # Base URL for reverse proxy
+NETRONOME__CHECK_FOR_UPDATES=true    # Check releases and show in-app update notifications
 
 # Database (SQLite by default)
 NETRONOME__DB_TYPE=sqlite            # sqlite or postgres
@@ -716,6 +717,14 @@ NETRONOME__OIDC_CLIENT_SECRET=your-secret
 NETRONOME__OIDC_REDIRECT_URL=https://example.com/api/auth/oidc/callback
 ```
 
+### Update notifications
+
+Netronome checks for new releases by default and shows an in-app notification. Disable it with this top-level setting, or `NETRONOME__CHECK_FOR_UPDATES=false`:
+
+```toml
+check_for_updates = false
+```
+
 <details>
 <summary><b>Complete Environment Variables Reference</b> (click to expand)</summary>
 
@@ -726,6 +735,7 @@ NETRONOME__HOST=127.0.0.1                    # Server listen address
 NETRONOME__PORT=7575                         # Server port
 NETRONOME__BASE_URL=/                        # Base URL path (for reverse proxy)
 NETRONOME__GIN_MODE=                         # Gin framework mode (debug/release/test)
+NETRONOME__CHECK_FOR_UPDATES=true            # Check releases and show in-app update notifications
 ```
 
 ### Database Configuration

--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/autobrr/netronome/internal/server"
 	"github.com/autobrr/netronome/internal/services/license"
 	"github.com/autobrr/netronome/internal/speedtest"
+	"github.com/autobrr/netronome/internal/update"
 	appversion "github.com/autobrr/netronome/internal/version"
 )
 
@@ -293,6 +294,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	// create server handler with packet loss service and monitor service
 	serverHandler := server.NewServer(speedtestSvc, db, schedulerSvc, cfg, packetLossService, monitorService, notifier, licenseService)
+	updateChecker := update.New(cfg.CheckForUpdates, appversion.Version, nil)
+	serverHandler.SetUpdateChecker(updateChecker)
 
 	speedtestSvc.SetBroadcastUpdate(serverHandler.BroadcastUpdate)
 	speedtestSvc.SetBroadcastTracerouteUpdate(serverHandler.BroadcastTracerouteUpdate)
@@ -328,6 +331,9 @@ func runServer(cmd *cobra.Command, args []string) error {
 	serverHandler.Initialize()
 
 	serverHandler.StartScheduler(context.Background())
+	updateCtx, cancelUpdateChecker := context.WithCancel(context.Background())
+	defer cancelUpdateChecker()
+	go updateChecker.Start(updateCtx)
 
 	// revalidate the premium license in the background (24h ticker, 7 day
 	// offline grace). Only meaningful when a Polar org was built in.
@@ -354,6 +360,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	<-quit
 
 	log.Info().Msg("Shutting down server...")
+	cancelUpdateChecker()
 
 	// the context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,5 +1,8 @@
 # Netronome Configuration
 
+# Check for new releases in the background and show available updates in the UI
+check_for_updates = true
+
 [database]
 type = "sqlite"
 path = "netronome.db"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/hashicorp/go-version v1.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/keygen-sh/machineid v1.1.3
 	github.com/lib/pq v1.12.3
@@ -60,7 +61,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
-	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,19 +36,20 @@ const (
 
 // Config represents the application configuration
 type Config struct {
-	Database   DatabaseConfig   `toml:"database"`
-	Server     ServerConfig     `toml:"server"`
-	Logging    LoggingConfig    `toml:"logging"`
-	Auth       AuthConfig       `toml:"auth"`
-	OIDC       OIDCConfig       `toml:"oidc"`
-	SpeedTest  SpeedTestConfig  `toml:"speedtest"`
-	GeoIP      GeoIPConfig      `toml:"geoip"`
-	Pagination PaginationConfig `toml:"pagination"`
-	Session    SessionConfig    `toml:"session"`
-	PacketLoss PacketLossConfig `toml:"packetloss"`
-	Agent      AgentConfig      `toml:"agent"`
-	Monitor    MonitorConfig    `toml:"monitor"`
-	Tailscale  TailscaleConfig  `toml:"tailscale"`
+	CheckForUpdates bool             `toml:"check_for_updates" env:"CHECK_FOR_UPDATES"`
+	Database        DatabaseConfig   `toml:"database"`
+	Server          ServerConfig     `toml:"server"`
+	Logging         LoggingConfig    `toml:"logging"`
+	Auth            AuthConfig       `toml:"auth"`
+	OIDC            OIDCConfig       `toml:"oidc"`
+	SpeedTest       SpeedTestConfig  `toml:"speedtest"`
+	GeoIP           GeoIPConfig      `toml:"geoip"`
+	Pagination      PaginationConfig `toml:"pagination"`
+	Session         SessionConfig    `toml:"session"`
+	PacketLoss      PacketLossConfig `toml:"packetloss"`
+	Agent           AgentConfig      `toml:"agent"`
+	Monitor         MonitorConfig    `toml:"monitor"`
+	Tailscale       TailscaleConfig  `toml:"tailscale"`
 }
 
 type DatabaseConfig struct {
@@ -226,6 +227,7 @@ func isRunningInContainer() bool {
 // New creates a new Config instance with default values
 func New() *Config {
 	return &Config{
+		CheckForUpdates: true,
 		Database: DatabaseConfig{
 			Type:    SQLite,
 			Host:    "localhost",
@@ -412,7 +414,16 @@ func (c *Config) loadFromEnv() error {
 	c.loadAgentFromEnv()
 	c.loadMonitorFromEnv()
 	c.loadTailscaleFromEnv()
+	c.loadUpdatesFromEnv()
 	return nil
+}
+
+func (c *Config) loadUpdatesFromEnv() {
+	if v := getEnv("CHECK_FOR_UPDATES"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			c.CheckForUpdates = enabled
+		}
+	}
 }
 
 func (c *Config) loadDatabaseFromEnv() {
@@ -698,6 +709,9 @@ func (c *Config) WriteToml(w io.Writer) error {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, ""); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "# Check for new releases in the background and show available updates in the UI\ncheck_for_updates = %v\n\n", cfg.CheckForUpdates); err != nil {
 		return err
 	}
 

--- a/internal/config/update_config_test.go
+++ b/internal/config/update_config_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckForUpdatesConfiguration(t *testing.T) {
+	t.Setenv("NETRONOME__CHECK_FOR_UPDATES", "false")
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("check_for_updates = true\n"), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.CheckForUpdates)
+
+	assert.True(t, New().CheckForUpdates)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/autobrr/netronome/internal/services/license"
 	"github.com/autobrr/netronome/internal/speedtest"
 	"github.com/autobrr/netronome/internal/types"
+	"github.com/autobrr/netronome/internal/update"
 	"github.com/autobrr/netronome/web"
 )
 
@@ -45,6 +46,11 @@ type Server struct {
 	lastMonitorUpdate    *types.MonitorUpdate
 	config               *config.Config
 	licenseService       *license.Service
+	updateChecker        *update.Checker
+}
+
+func (s *Server) SetUpdateChecker(checker *update.Checker) {
+	s.updateChecker = checker
 }
 
 func NewServer(speedtest speedtest.Service, db database.Service, scheduler scheduler.Service, cfg *config.Config, packetLossService *speedtest.PacketLossService, monitorService *monitor.Service, notifier *notifications.Notifier, licenseService *license.Service) *Server {
@@ -242,6 +248,7 @@ func (s *Server) RegisterRoutes() {
 			protected.POST("/auth/logout", s.auth.Logout)
 			protected.GET("/auth/verify", s.auth.Verify)
 			protected.GET("/auth/user", s.auth.GetUserInfo)
+			protected.GET("/version/latest", s.handleLatestVersion)
 
 			protected.GET("/license", licenseHandler.GetLicense)
 			protected.POST("/license/activate", licenseHandler.ActivateLicense)

--- a/internal/server/update.go
+++ b/internal/server/update.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleLatestVersion(c *gin.Context) {
+	if s.updateChecker == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	latest := s.updateChecker.Latest()
+	if latest == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	c.JSON(http.StatusOK, struct {
+		TagName     string `json:"tag_name"`
+		Name        string `json:"name,omitempty"`
+		HTMLURL     string `json:"html_url"`
+		PublishedAt string `json:"published_at"`
+	}{
+		TagName:     latest.TagName,
+		Name:        latest.Name,
+		HTMLURL:     latest.HTMLURL,
+		PublishedAt: latest.PublishedAt.UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/server/update_test.go
+++ b/internal/server/update_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/config"
+	"github.com/autobrr/netronome/internal/update"
+)
+
+func TestLatestVersionRouteUsesBaseURLAndReturnsCachedRelease(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	releaseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"tag_name":"v1.2.4","name":"Netronome 1.2.4","html_url":"https://example.test/releases/v1.2.4","published_at":"2026-07-30T14:00:00+02:00"}`)
+	}))
+	defer releaseServer.Close()
+
+	checker := update.New(true, "1.2.3", serverClient(t, releaseServer.URL))
+	require.NoError(t, checker.Check(context.Background()))
+
+	cfg := config.New()
+	cfg.Server.BaseURL = "/netronome"
+	cfg.Auth.Whitelist = []string{"127.0.0.1/32"}
+	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil)
+	server.SetUpdateChecker(checker)
+	server.RegisterRoutes()
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/netronome/api/version/latest", nil)
+	request.RemoteAddr = "127.0.0.1:12345"
+	server.Router.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	assert.JSONEq(t, `{"tag_name":"v1.2.4","name":"Netronome 1.2.4","html_url":"https://example.test/releases/v1.2.4","published_at":"2026-07-30T12:00:00Z"}`, response.Body.String())
+}
+
+func TestLatestVersionRouteReturnsNoContentWithoutCachedRelease(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.New()
+	cfg.Auth.Whitelist = []string{"127.0.0.1/32"}
+	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil)
+	server.SetUpdateChecker(update.New(false, "1.2.3", nil))
+	server.RegisterRoutes()
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/version/latest", nil)
+	request.RemoteAddr = "127.0.0.1:12345"
+	server.Router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusNoContent, response.Code)
+	assert.Empty(t, response.Body.String())
+}
+
+func serverClient(t *testing.T, target string) *http.Client {
+	t.Helper()
+	targetURL, err := url.Parse(target)
+	require.NoError(t, err)
+
+	return &http.Client{Transport: serverRoundTripper(func(r *http.Request) (*http.Response, error) {
+		clone := r.Clone(r.Context())
+		clone.URL.Scheme = targetURL.Scheme
+		clone.URL.Host = targetURL.Host
+		return http.DefaultTransport.RoundTrip(clone)
+	})}
+}
+
+type serverRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f serverRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/rs/zerolog/log"
+)
+
+const latestReleaseURL = "https://api.autobrr.com/repos/autobrr/netronome/releases/latest"
+
+// Release is the release metadata shown in the UI when an update is available.
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name,omitempty"`
+	HTMLURL     string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// Checker periodically checks the Netronome release feed and keeps the newest
+// applicable release in memory.
+type Checker struct {
+	enabled        bool
+	currentVersion string
+	client         *http.Client
+
+	mu     sync.RWMutex
+	latest *Release
+}
+
+func New(enabled bool, currentVersion string, client *http.Client) *Checker {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	return &Checker{
+		enabled:        enabled,
+		currentVersion: currentVersion,
+		client:         client,
+	}
+}
+
+// Start performs the initial check after two seconds, then checks every two
+// hours until ctx is cancelled.
+func (c *Checker) Start(ctx context.Context) {
+	if !c.enabled || !isCheckableVersion(c.currentVersion) {
+		return
+	}
+
+	initial := time.NewTimer(2 * time.Second)
+	defer initial.Stop()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-initial.C:
+		c.checkAndLog(ctx)
+	}
+
+	ticker := time.NewTicker(2 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.checkAndLog(ctx)
+		}
+	}
+}
+
+func (c *Checker) checkAndLog(ctx context.Context) {
+	if err := c.Check(ctx); err != nil && ctx.Err() == nil {
+		log.Warn().Err(err).Msg("Failed to check for Netronome updates")
+	}
+}
+
+// Check fetches the latest release and updates the in-memory cache. Errors do
+// not modify an existing cached update.
+func (c *Checker) Check(ctx context.Context) error {
+	if !c.enabled || !isCheckableVersion(c.currentVersion) {
+		return nil
+	}
+
+	release, err := c.fetch(ctx)
+	if err != nil {
+		return err
+	}
+
+	isNewer, err := IsNewer(c.currentVersion, release.TagName)
+	if err != nil {
+		return fmt.Errorf("compare releases: %w", err)
+	}
+
+	c.mu.Lock()
+	if isNewer {
+		changed := c.latest == nil || c.latest.TagName != release.TagName
+		c.latest = &release
+		c.mu.Unlock()
+		if changed {
+			log.Info().Str("tag", release.TagName).Msg("New Netronome release detected")
+		}
+		return nil
+	}
+	c.latest = nil
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Checker) fetch(ctx context.Context) (Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return Release{}, fmt.Errorf("create latest release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", fmt.Sprintf("netronome/%s (%s %s)", c.currentVersion, runtime.GOOS, runtime.GOARCH))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return Release{}, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Release{}, fmt.Errorf("fetch latest release: unexpected status %s", resp.Status)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return Release{}, fmt.Errorf("decode latest release: %w", err)
+	}
+	releaseURL, err := url.Parse(release.HTMLURL)
+	if err != nil || releaseURL.Scheme != "https" || releaseURL.Host == "" {
+		return Release{}, fmt.Errorf("decode latest release: unsafe release URL %q", release.HTMLURL)
+	}
+	return release, nil
+}
+
+// Latest returns a copy of the cached update, if one is available.
+func (c *Checker) Latest() *Release {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.latest == nil {
+		return nil
+	}
+	latest := *c.latest
+	return &latest
+}
+
+// IsNewer reports whether latest is a strictly newer release than current.
+func IsNewer(current, latest string) (bool, error) {
+	currentVersion, err := version.NewVersion(current)
+	if err != nil {
+		return false, fmt.Errorf("parse current version %q: %w", current, err)
+	}
+	latestVersion, err := version.NewVersion(latest)
+	if err != nil {
+		return false, fmt.Errorf("parse latest version %q: %w", latest, err)
+	}
+
+	if currentVersion.Prerelease() == "" && latestVersion.Prerelease() != "" {
+		return false, nil
+	}
+	return latestVersion.GreaterThan(currentVersion), nil
+}
+
+func isCheckableVersion(current string) bool {
+	current = strings.ToLower(strings.TrimSpace(current))
+	if current == "" || current == "dev" || current == "develop" || current == "main" || current == "latest" {
+		return false
+	}
+	if strings.Contains(current, "(devel)") || strings.HasPrefix(current, "pr-") {
+		return false
+	}
+	return !strings.HasSuffix(current, "-dev") && !strings.HasSuffix(current, "-develop")
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{name: "newer stable release", current: "v1.2.3", latest: "v1.2.4", want: true},
+		{name: "same release", current: "1.2.3", latest: "v1.2.3", want: false},
+		{name: "older release", current: "1.2.4", latest: "v1.2.3", want: false},
+		{name: "stable current ignores newer prerelease", current: "1.2.3", latest: "1.3.0-rc.1", want: false},
+		{name: "prerelease current accepts newer stable", current: "1.3.0-rc.1", latest: "1.3.0", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsNewer(tt.current, tt.latest)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckSkipsDevelopmentVersionsWithoutNetworkRequest(t *testing.T) {
+	versions := []string{"", "dev", "develop", "main", "latest", "pr-123", "1.2.3-dev", "1.2.3-develop", "1.2.3 (devel)"}
+
+	for _, current := range versions {
+		t.Run(current, func(t *testing.T) {
+			var requests atomic.Int32
+			client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return nil, assert.AnError
+			})}
+			checker := New(true, current, client)
+
+			require.NoError(t, checker.Check(context.Background()))
+			assert.Zero(t, requests.Load())
+			assert.Nil(t, checker.Latest())
+		})
+	}
+}
+
+func TestCheckCachesNewerReleaseAndSendsReleaseHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/vnd.github.v3+json" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got, want := r.UserAgent(), "netronome/1.2.3 ("+runtime.GOOS+" "+runtime.GOARCH+")"; got != want {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = io.WriteString(w, `{"tag_name":"v1.2.4","name":"Netronome 1.2.4","html_url":"https://example.test/releases/v1.2.4","published_at":"2026-07-30T12:00:00Z","ignored":"value"}`)
+	}))
+	defer server.Close()
+
+	checker := New(true, "1.2.3", rewriteClient(t, server.URL))
+	require.NoError(t, checker.Check(context.Background()))
+
+	assert.Equal(t, &Release{
+		TagName:     "v1.2.4",
+		Name:        "Netronome 1.2.4",
+		HTMLURL:     "https://example.test/releases/v1.2.4",
+		PublishedAt: time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC),
+	}, checker.Latest())
+}
+
+func TestCheckRetainsCachedUpdateOnFailureAndClearsItWhenCurrent(t *testing.T) {
+	var mode atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		switch mode.Load() {
+		case 0:
+			_, _ = io.WriteString(w, `{"tag_name":"v1.2.4","html_url":"https://example.test/releases/v1.2.4","published_at":"2026-07-30T12:00:00Z"}`)
+		case 1:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"tag_name":"v1.2.5","html_url":"https://example.test/releases/v1.2.5","published_at":"2026-07-30T12:00:00Z"}`)
+		case 2:
+			_, _ = io.WriteString(w, `{"tag_name":"v1.2.3","html_url":"https://example.test/releases/v1.2.3","published_at":"2026-07-30T12:00:00Z"}`)
+		default:
+			_, _ = io.WriteString(w, `{"tag_name":"v1.2.5","html_url":"javascript:alert(1)","published_at":"2026-07-30T12:00:00Z"}`)
+		}
+	}))
+	defer server.Close()
+
+	checker := New(true, "1.2.3", rewriteClient(t, server.URL))
+	require.NoError(t, checker.Check(context.Background()))
+	first := checker.Latest()
+	require.NotNil(t, first)
+
+	mode.Store(1)
+	require.Error(t, checker.Check(context.Background()))
+	assert.Equal(t, first, checker.Latest())
+
+	mode.Store(3)
+	require.Error(t, checker.Check(context.Background()))
+	assert.Equal(t, first, checker.Latest())
+
+	mode.Store(2)
+	require.NoError(t, checker.Check(context.Background()))
+	assert.Nil(t, checker.Latest())
+}
+
+func TestCheckCancellationRetainsCachedUpdate(t *testing.T) {
+	checker := New(true, "1.2.3", &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})})
+	checker.mu.Lock()
+	checker.latest = &Release{TagName: "v1.2.4"}
+	checker.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, checker.Check(ctx), context.Canceled)
+	assert.Equal(t, "v1.2.4", checker.Latest().TagName)
+}
+
+func TestStartStopsWhenContextIsCancelledBeforeInitialCheck(t *testing.T) {
+	checker := New(true, "1.2.3", &http.Client{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		checker.Start(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("checker did not stop after context cancellation")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func rewriteClient(t *testing.T, target string) *http.Client {
+	t.Helper()
+	targetURL, err := url.Parse(target)
+	require.NoError(t, err)
+
+	return &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		clone := r.Clone(r.Context())
+		clone.URL.Scheme = targetURL.Scheme
+		clone.URL.Host = targetURL.Host
+		return http.DefaultTransport.RoundTrip(clone)
+	})}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,8 +4,12 @@
  */
 
 import { useEffect, useState, useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Outlet } from "@tanstack/react-router";
-import { ArrowRightStartOnRectangleIcon as LogoutIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowRightStartOnRectangleIcon as LogoutIcon,
+  ArrowTopRightOnSquareIcon,
+} from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/solid";
 import {
   Bars3Icon,
@@ -38,9 +42,25 @@ import {
 } from "@/components/ui/sheet";
 import logo from "@/assets/logo_small.png";
 import { PWAUpdatePrompt } from "@/components/PWAUpdatePrompt";
+import {
+  formatReleaseTag,
+  getLatestRelease,
+  latestReleaseQueryKey,
+} from "@/api/version";
+import { AppUpdatePrompt } from "@/components/AppUpdatePrompt";
+
+const RELEASE_POLL_INTERVAL = 2 * 60 * 1000;
 
 function App() {
   const { isAuthenticated, logout } = useAuth();
+  const { data: latestRelease } = useQuery({
+    queryKey: latestReleaseQueryKey,
+    queryFn: getLatestRelease,
+    enabled: isAuthenticated,
+    staleTime: RELEASE_POLL_INTERVAL,
+    refetchInterval: RELEASE_POLL_INTERVAL,
+    refetchOnWindowFocus: false,
+  });
   const [isDonateOpen, setIsDonateOpen] = useState(false);
   const [mobileSettingsSection, setMobileSettingsSection] = useState<
     string | null
@@ -84,6 +104,7 @@ function App() {
   // Check if we're on the public route
   const isPublicRoute = window.location.pathname.includes("/public");
   const showHeader = isAuthenticated || isPublicRoute;
+  const availableRelease = isAuthenticated ? latestRelease ?? null : null;
 
   return (
     <div className="min-h-screen bg-white pattern dark:bg-gray-900 relative transition-colors duration-300 ease-in-out">
@@ -125,7 +146,7 @@ function App() {
               <HeartIcon className="h-6 w-6" />
             </Button>
             <ThemeDropdown />
-            <SettingsMenu />
+            <SettingsMenu release={availableRelease} />
             <Button
               onClick={() => logout()}
               variant="ghost"
@@ -144,10 +165,20 @@ function App() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
-                  aria-label="Open menu"
+                  className="relative text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+                  aria-label={
+                    availableRelease
+                      ? `Open menu, Netronome ${formatReleaseTag(availableRelease.tag_name)} update available`
+                      : "Open menu"
+                  }
                 >
                   <Bars3Icon className="h-6 w-6" />
+                  {availableRelease && (
+                    <span
+                      aria-hidden="true"
+                      className="absolute right-1 top-1 h-2 w-2 rounded-full bg-blue-500 ring-2 ring-white dark:ring-gray-900"
+                    />
+                  )}
                 </Button>
               </SheetTrigger>
               <SheetContent
@@ -163,6 +194,30 @@ function App() {
 
                   <div className="flex-1 py-6">
                     <div className="space-y-2">
+                      {availableRelease && (
+                        <Button
+                          asChild
+                          variant="ghost"
+                          className="h-auto w-full justify-start gap-3 px-4 py-3"
+                        >
+                          <a
+                            href={availableRelease.html_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => setMobileMenuOpen(false)}
+                            aria-label={`View Netronome ${formatReleaseTag(availableRelease.tag_name)} release`}
+                          >
+                            <ArrowTopRightOnSquareIcon className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+                            <span className="flex-1 text-left text-sm font-medium text-gray-700 dark:text-gray-300">
+                              Netronome {formatReleaseTag(availableRelease.tag_name)} available
+                            </span>
+                            <span className="text-xs text-blue-600 dark:text-blue-400">
+                              View release
+                            </span>
+                          </a>
+                        </Button>
+                      )}
+
                       {/* Support */}
                       <Button
                         onClick={() => {
@@ -256,6 +311,7 @@ function App() {
 
       <Outlet />
       <Toaster position="bottom-right" />
+      <AppUpdatePrompt release={availableRelease} />
       <PWAUpdatePrompt />
     </div>
   );

--- a/web/src/api/version.ts
+++ b/web/src/api/version.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getApiUrl } from "@/utils/baseUrl";
+
+export interface AppRelease {
+  tag_name: string;
+  name?: string;
+  html_url: string;
+  published_at: string;
+}
+
+export const latestReleaseQueryKey = ["version", "latest"] as const;
+
+const isSafeReleaseUrl = (value: string): boolean => {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const isAppRelease = (value: unknown): value is AppRelease => {
+  if (!value || typeof value !== "object") return false;
+
+  const release = value as Record<string, unknown>;
+  return (
+    typeof release.tag_name === "string" &&
+    typeof release.html_url === "string" &&
+    isSafeReleaseUrl(release.html_url) &&
+    typeof release.published_at === "string" &&
+    (release.name === undefined || typeof release.name === "string")
+  );
+};
+
+export async function getLatestRelease(): Promise<AppRelease | null> {
+  const response = await fetch(getApiUrl("/version/latest"), {
+    credentials: "include",
+  });
+
+  if (response.status === 204) return null;
+  if (response.status !== 200) {
+    throw new Error(response.statusText || "Failed to fetch latest release");
+  }
+
+  const release: unknown = await response.json();
+  if (!isAppRelease(release)) {
+    throw new Error("Invalid latest release response");
+  }
+
+  return release;
+}
+
+export function formatReleaseTag(tagName: string): string {
+  return tagName.startsWith("v") ? tagName : `v${tagName}`;
+}

--- a/web/src/components/AppUpdatePrompt.tsx
+++ b/web/src/components/AppUpdatePrompt.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useEffect, useRef } from "react";
+import { toast } from "@/components/common/Toast";
+import { formatReleaseTag, type AppRelease } from "@/api/version";
+
+const DISMISSED_RELEASE_STORAGE_KEY = "netronome.dismissedReleaseTag";
+
+const getDismissedReleaseTag = (): string | null => {
+  try {
+    return localStorage.getItem(DISMISSED_RELEASE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const dismissReleaseTag = (tagName: string) => {
+  try {
+    localStorage.setItem(DISMISSED_RELEASE_STORAGE_KEY, tagName);
+  } catch {
+    // Storage can be unavailable in private browsing modes; the current toast
+    // still closes and a future session can try again.
+  }
+};
+
+const openRelease = (url: string) => {
+  const releaseWindow = window.open(url, "_blank", "noopener,noreferrer");
+  if (releaseWindow) releaseWindow.opener = null;
+};
+
+/** Persistent release notice. The menu markers remain after it is dismissed. */
+export function AppUpdatePrompt({ release }: { release: AppRelease | null }) {
+  const toastIdRef = useRef<string | number | null>(null);
+  const shownTagRef = useRef<string | null>(null);
+  const programmaticDismissalsRef = useRef(new Set<string | number>());
+
+  useEffect(() => {
+    const dismissCurrentToast = () => {
+      const toastId = toastIdRef.current;
+      if (toastId === null) return;
+
+      programmaticDismissalsRef.current.add(toastId);
+      toast.dismiss(toastId);
+      toastIdRef.current = null;
+      shownTagRef.current = null;
+    };
+
+    if (!release || getDismissedReleaseTag() === release.tag_name) {
+      dismissCurrentToast();
+      return;
+    }
+
+    if (toastIdRef.current !== null) {
+      if (shownTagRef.current === release.tag_name) return;
+      dismissCurrentToast();
+    }
+
+    const toastId = toast.info(
+      `Netronome ${formatReleaseTag(release.tag_name)} is available`,
+      {
+        duration: Infinity,
+        action: {
+          label: "View release",
+          onClick: () => {
+            openRelease(release.html_url);
+            dismissReleaseTag(release.tag_name);
+            toastIdRef.current = null;
+            shownTagRef.current = null;
+          },
+        },
+        cancel: {
+          label: "Later",
+          onClick: () => {
+            dismissReleaseTag(release.tag_name);
+            toastIdRef.current = null;
+            shownTagRef.current = null;
+          },
+        },
+        onDismiss: () => {
+          if (!programmaticDismissalsRef.current.delete(toastId)) {
+            dismissReleaseTag(release.tag_name);
+          }
+          if (toastIdRef.current === toastId) {
+            toastIdRef.current = null;
+            shownTagRef.current = null;
+          }
+        },
+      }
+    );
+
+    toastIdRef.current = toastId;
+    shownTagRef.current = release.tag_name;
+  }, [release]);
+
+  useEffect(
+    () => () => {
+      const toastId = toastIdRef.current;
+      if (toastId === null) return;
+
+      programmaticDismissalsRef.current.add(toastId);
+      toast.dismiss(toastId);
+      toastIdRef.current = null;
+      shownTagRef.current = null;
+    },
+    []
+  );
+
+  return null;
+}

--- a/web/src/components/SettingsMenu.tsx
+++ b/web/src/components/SettingsMenu.tsx
@@ -12,6 +12,7 @@ import {
   PresentationChartLineIcon,
   CircleStackIcon,
   SwatchIcon,
+  ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import { NotificationSettings } from "./settings/NotificationSettings";
 import { TimeFormatSettings } from "./settings/TimeFormatSettings";
@@ -30,8 +31,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { formatReleaseTag, type AppRelease } from "@/api/version";
 
 interface SettingsSection {
   id: string;
@@ -113,7 +116,9 @@ export const SettingsDialog: React.FC<{
   );
 };
 
-export const SettingsMenu: React.FC = () => {
+export const SettingsMenu: React.FC<{ release: AppRelease | null }> = ({
+  release,
+}) => {
   const [activeSection, setActiveSection] = useState<string | null>(null);
 
   return (
@@ -123,16 +128,49 @@ export const SettingsMenu: React.FC = () => {
           <Button
             variant="ghost"
             size="icon"
-            className="text-gray-600 dark:text-gray-600 hover:text-gray-900 dark:hover:text-gray-400"
-            aria-label="Settings"
+            className="relative text-gray-600 dark:text-gray-600 hover:text-gray-900 dark:hover:text-gray-400"
+            aria-label={
+              release
+                ? `Settings, Netronome ${formatReleaseTag(release.tag_name)} update available`
+                : "Settings"
+            }
           >
             <Cog6ToothIcon className="w-6 h-6" />
+            {release && (
+              <span
+                aria-hidden="true"
+                className="absolute right-1 top-1 h-2 w-2 rounded-full bg-blue-500 ring-2 ring-white dark:ring-gray-900"
+              />
+            )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
           className="w-56 bg-white dark:bg-gray-800 shadow-xl ring-1 ring-black/10 dark:ring-white/10"
         >
+          {release && (
+            <>
+              <DropdownMenuItem asChild>
+                <a
+                  href={release.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`View Netronome ${formatReleaseTag(release.tag_name)} release`}
+                  className="cursor-pointer px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  <ArrowTopRightOnSquareIcon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                  <span className="flex-1 text-left font-medium">
+                    Netronome {formatReleaseTag(release.tag_name)} available
+                  </span>
+                  <span className="text-xs text-blue-600 dark:text-blue-400">
+                    View release
+                  </span>
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+
           {settingsSections.map((section) => (
             <DropdownMenuItem
               key={section.id}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -115,6 +115,10 @@ export default defineConfig({
             }
           },
           {
+            urlPattern: /\/api\/version\/latest$/,
+            handler: 'NetworkOnly'
+          },
+          {
             urlPattern: /\/api\/.*/,
             handler: 'NetworkFirst',
             options: {


### PR DESCRIPTION
Adds a Qui-style release checker backed by api.autobrr.com, exposes cached update metadata to authenticated clients, and makes checks configurable for self-hosted deployments.

Surfaces available releases through a dismissible toast and persistent desktop/mobile menu indicators, with per-release dismissal, safe external links, and protection against stale service-worker responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic release update checks and notifications.
  * Users can view available releases from the settings menu or an in-app prompt.
  * Added configuration options to enable or disable update checks.
  * Update notifications can be dismissed and revisited through the release link.

* **Documentation**
  * Documented the new update-check configuration and environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->