### PR TITLE
fix(speedtest): pin parallel stream count instead of following host CPU count

### DIFF
--- a/internal/speedtest/speedtest_net.go
+++ b/internal/speedtest/speedtest_net.go
@@ -101,8 +101,14 @@ func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOption
 	}
 	defer func() { <-r.running }()
 
+	// Both cases above can become ready together when the slot frees, and Go
+	// then picks one at random, so the caller may have given up while queued.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Deferred so the early returns below cannot leave stale state on the
-	// client. Registered second, so it runs before the slot is released.
+	// client. Registered after the release, so it runs while the slot is held.
 	defer r.client.Reset()
 
 	log.Debug().

--- a/internal/speedtest/speedtest_net.go
+++ b/internal/speedtest/speedtest_net.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,8 +39,10 @@ const (
 
 type SpeedtestNetRunner struct {
 	// speedtest-go keeps its counters on the client, so two tests sharing one
-	// client corrupt each other. Tests are serialised rather than rejected.
-	mu               sync.Mutex
+	// client corrupt each other. Tests queue for this slot rather than being
+	// rejected, but a caller that gives up while queued leaves without starting
+	// a test its deadline has already passed.
+	running          chan struct{}
 	client           *st.Speedtest
 	config           config.SpeedTestConfig
 	progressCallback func(types.SpeedUpdate)
@@ -52,6 +53,7 @@ type SpeedtestNetRunner struct {
 
 func NewSpeedtestNetRunner(cfg config.SpeedTestConfig) *SpeedtestNetRunner {
 	return &SpeedtestNetRunner{
+		running:       make(chan struct{}, 1),
 		client:        st.New(st.WithUserConfig(&st.UserConfig{MaxConnections: speedtestStreams})),
 		config:        cfg,
 		cacheDuration: 30 * time.Minute,
@@ -92,10 +94,15 @@ func (r *SpeedtestNetRunner) SetProgressCallback(callback func(types.SpeedUpdate
 }
 
 func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOptions) (*Result, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	select {
+	case r.running <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	defer func() { <-r.running }()
 
-	// Deferred so the early returns below cannot leave stale state on the client.
+	// Deferred so the early returns below cannot leave stale state on the
+	// client. Registered second, so it runs before the slot is released.
 	defer r.client.Reset()
 
 	log.Debug().
@@ -145,6 +152,9 @@ func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOption
 			return nil, fmt.Errorf("requested server(s) %v not found in public list or by direct lookup", opts.ServerIDs)
 		}
 		selectedServer = selectNearestServer(serverList)
+		if selectedServer == nil {
+			return nil, fmt.Errorf("no speedtest servers available")
+		}
 	}
 
 	log.Info().

--- a/internal/speedtest/speedtest_net.go
+++ b/internal/speedtest/speedtest_net.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,7 +20,28 @@ import (
 	"github.com/autobrr/netronome/internal/types"
 )
 
+const (
+	// speedtest-go defaults its parallel stream count to runtime.NumCPU(), which
+	// makes a result depend on how many cores the host has instead of on the
+	// line. A single TCP stream cannot fill a fast or high-latency path, so a
+	// 4-core box measured about half the upload of a 16-core box on the same
+	// line. Pin the count so every host runs the same test. On a path where one
+	// stream already saturates the line the extra streams change nothing, and
+	// they cost almost no CPU.
+	speedtestStreams = 16
+
+	// Ookla reports the same distance for every server in a city, so sorting by
+	// distance alone leaves a large tie that resolves arbitrarily. Servers this
+	// close to the nearest one count as tied and the tie goes to the lowest
+	// latency. Without the limit a distant server with a quick ping would beat a
+	// much closer one.
+	speedtestDistanceTieKm = 5.0
+)
+
 type SpeedtestNetRunner struct {
+	// speedtest-go keeps its counters on the client, so two tests sharing one
+	// client corrupt each other. Tests are serialised rather than rejected.
+	mu               sync.Mutex
 	client           *st.Speedtest
 	config           config.SpeedTestConfig
 	progressCallback func(types.SpeedUpdate)
@@ -30,11 +52,35 @@ type SpeedtestNetRunner struct {
 
 func NewSpeedtestNetRunner(cfg config.SpeedTestConfig) *SpeedtestNetRunner {
 	return &SpeedtestNetRunner{
-		client:        st.New(),
+		client:        st.New(st.WithUserConfig(&st.UserConfig{MaxConnections: speedtestStreams})),
 		config:        cfg,
 		cacheDuration: 30 * time.Minute,
 		cacheExpiry:   time.Now(),
 	}
+}
+
+// selectNearestServer returns the closest server, breaking distance ties on the
+// latency that FetchServers() already measured. Latency is st.PingTimeout (-1)
+// when that ping failed, so only positive values count. Sorts in place.
+func selectNearestServer(servers []*st.Server) *st.Server {
+	if len(servers) == 0 {
+		return nil
+	}
+
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i].Distance < servers[j].Distance
+	})
+
+	best := servers[0]
+	for _, server := range servers[1:] {
+		if server.Distance > servers[0].Distance+speedtestDistanceTieKm {
+			break
+		}
+		if server.Latency > 0 && (best.Latency <= 0 || server.Latency < best.Latency) {
+			best = server
+		}
+	}
+	return best
 }
 
 func (r *SpeedtestNetRunner) GetTestType() string {
@@ -46,6 +92,12 @@ func (r *SpeedtestNetRunner) SetProgressCallback(callback func(types.SpeedUpdate
 }
 
 func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOptions) (*Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Deferred so the early returns below cannot leave stale state on the client.
+	defer r.client.Reset()
+
 	log.Debug().
 		Bool("isScheduled", opts.IsScheduled).
 		Str("server_ids", fmt.Sprintf("%v", opts.ServerIDs)).
@@ -92,10 +144,7 @@ func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOption
 		if len(opts.ServerIDs) > 0 {
 			return nil, fmt.Errorf("requested server(s) %v not found in public list or by direct lookup", opts.ServerIDs)
 		}
-		sort.Slice(serverList, func(i, j int) bool {
-			return serverList[i].Distance < serverList[j].Distance
-		})
-		selectedServer = serverList[0]
+		selectedServer = selectNearestServer(serverList)
 	}
 
 	log.Info().
@@ -281,8 +330,6 @@ func (r *SpeedtestNetRunner) RunTest(ctx context.Context, opts *types.TestOption
 		Float64("download_mbps", result.DownloadSpeed).
 		Float64("upload_mbps", result.UploadSpeed).
 		Msg("Speedtest.net test complete")
-
-	selectedServer.Context.Reset()
 
 	jitterFloat := selectedServer.Jitter.Seconds() * 1000
 	result.Jitter = jitterFloat

--- a/internal/speedtest/speedtest_net_test.go
+++ b/internal/speedtest/speedtest_net_test.go
@@ -17,9 +17,9 @@ import (
 
 // A caller whose deadline passes while it waits for a running test must give up
 // instead of starting a test nobody is waiting for any more.
-func TestRunTestGivesUpWhenCallerCancels(t *testing.T) {
+func TestRunTestGivesUpWhenQueuedBehindARunningTest(t *testing.T) {
 	r := NewSpeedtestNetRunner(config.SpeedTestConfig{Timeout: 60})
-	r.running <- struct{}{} // pretend another test holds the slot
+	r.running <- struct{}{} // another test holds the slot
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -29,31 +29,32 @@ func TestRunTestGivesUpWhenCallerCancels(t *testing.T) {
 	}
 }
 
-// The caller is still waiting when it gives up. Once the slot frees, both
-// select cases are ready and Go picks one at random, so the cancellation has to
-// be rechecked after the slot is taken.
-func TestRunTestGivesUpWhenCancelledWhileQueued(t *testing.T) {
-	r := NewSpeedtestNetRunner(config.SpeedTestConfig{Timeout: 60})
-	r.running <- struct{}{} // another test holds the slot
+// Nothing is running, so taking the slot and observing the cancellation are both
+// ready when the select is evaluated, and Go then picks one at random. Taking
+// the slot must not be enough to start the test. No single run can force the
+// random choice, so repeat: without the recheck about half of these reach the
+// network and return something other than context.Canceled.
+func TestRunTestGivesUpWhenSlotIsFree(t *testing.T) {
+	for i := range 20 {
+		r := NewSpeedtestNetRunner(config.SpeedTestConfig{Timeout: 60})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	errc := make(chan error, 1)
-	go func() {
-		_, err := r.RunTest(ctx, &types.TestOptions{})
-		errc <- err
-	}()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
-	time.Sleep(50 * time.Millisecond) // let RunTest reach the select
-	cancel()
-	<-r.running // the other test finishes, freeing the slot
+		errc := make(chan error, 1)
+		go func() {
+			_, err := r.RunTest(ctx, &types.TestOptions{})
+			errc <- err
+		}()
 
-	select {
-	case err := <-errc:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("got %v, want context.Canceled", err)
+		select {
+		case err := <-errc:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("run %d: got %v, want context.Canceled", i, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("run %d: RunTest started a test for a caller that had given up", i)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("RunTest started a test for a caller that had given up")
 	}
 }
 

--- a/internal/speedtest/speedtest_net_test.go
+++ b/internal/speedtest/speedtest_net_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package speedtest
+
+import (
+	"testing"
+	"time"
+
+	st "github.com/showwin/speedtest-go/speedtest"
+)
+
+func TestSelectNearestServer(t *testing.T) {
+	server := func(name string, distance float64, latency time.Duration) *st.Server {
+		return &st.Server{Name: name, Distance: distance, Latency: latency}
+	}
+
+	tests := []struct {
+		name    string
+		servers []*st.Server
+		want    string
+	}{
+		{
+			name:    "no servers",
+			servers: nil,
+			want:    "",
+		},
+		{
+			name:    "single server",
+			servers: []*st.Server{server("only", 10, 20*time.Millisecond)},
+			want:    "only",
+		},
+		{
+			name: "closest wins when distances differ",
+			servers: []*st.Server{
+				server("far", 100, 1*time.Millisecond),
+				server("near", 10, 50*time.Millisecond),
+			},
+			want: "near",
+		},
+		{
+			name: "equal distance is broken on latency",
+			servers: []*st.Server{
+				server("slow", 23.5, 15*time.Millisecond),
+				server("fast", 23.5, 8*time.Millisecond),
+				server("mid", 23.5, 12*time.Millisecond),
+			},
+			want: "fast",
+		},
+		{
+			name: "failed ping never wins",
+			servers: []*st.Server{
+				server("unreachable", 23.5, st.PingTimeout),
+				server("reachable", 23.5, 30*time.Millisecond),
+			},
+			want: "reachable",
+		},
+		{
+			name: "all pings failed falls back to the closest",
+			servers: []*st.Server{
+				server("closest", 10, st.PingTimeout),
+				server("further", 20, st.PingTimeout),
+			},
+			want: "closest",
+		},
+		{
+			name: "a distant server never wins on latency",
+			servers: []*st.Server{
+				server("c1", 1, 20*time.Millisecond),
+				server("c2", 2, 20*time.Millisecond),
+				server("c3", 3, 20*time.Millisecond),
+				server("c4", 4, 20*time.Millisecond),
+				server("c5", 5, 20*time.Millisecond),
+				server("distant-but-quick", 900, 1*time.Millisecond),
+			},
+			want: "c1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectNearestServer(tt.servers)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("got %q, want nil", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil, want %q", tt.want)
+			}
+			if got.Name != tt.want {
+				t.Errorf("got %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}

--- a/internal/speedtest/speedtest_net_test.go
+++ b/internal/speedtest/speedtest_net_test.go
@@ -29,6 +29,34 @@ func TestRunTestGivesUpWhenCallerCancels(t *testing.T) {
 	}
 }
 
+// The caller is still waiting when it gives up. Once the slot frees, both
+// select cases are ready and Go picks one at random, so the cancellation has to
+// be rechecked after the slot is taken.
+func TestRunTestGivesUpWhenCancelledWhileQueued(t *testing.T) {
+	r := NewSpeedtestNetRunner(config.SpeedTestConfig{Timeout: 60})
+	r.running <- struct{}{} // another test holds the slot
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := r.RunTest(ctx, &types.TestOptions{})
+		errc <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let RunTest reach the select
+	cancel()
+	<-r.running // the other test finishes, freeing the slot
+
+	select {
+	case err := <-errc:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunTest started a test for a caller that had given up")
+	}
+}
+
 func TestSelectNearestServer(t *testing.T) {
 	server := func(name string, distance float64, latency time.Duration) *st.Server {
 		return &st.Server{Name: name, Distance: distance, Latency: latency}

--- a/internal/speedtest/speedtest_net_test.go
+++ b/internal/speedtest/speedtest_net_test.go
@@ -4,11 +4,30 @@
 package speedtest
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	st "github.com/showwin/speedtest-go/speedtest"
+
+	"github.com/autobrr/netronome/internal/config"
+	"github.com/autobrr/netronome/internal/types"
 )
+
+// A caller whose deadline passes while it waits for a running test must give up
+// instead of starting a test nobody is waiting for any more.
+func TestRunTestGivesUpWhenCallerCancels(t *testing.T) {
+	r := NewSpeedtestNetRunner(config.SpeedTestConfig{Timeout: 60})
+	r.running <- struct{}{} // pretend another test holds the slot
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := r.RunTest(ctx, &types.TestOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want context.Canceled", err)
+	}
+}
 
 func TestSelectNearestServer(t *testing.T) {
 	server := func(name string, distance float64, latency time.Duration) *st.Server {


### PR DESCRIPTION
speedtest-go takes its parallel stream count from `runtime.NumCPU()`. The result therefore depended on the host, not on the line. Users with 4-core boxes reported speeds well below the Ookla app on the same connection. Upload suffered most. On a path where one TCP stream cannot fill the line, 4 streams measured 179 Mbps upload where 24 measured 995. On a fast, low-latency path the count made no difference: 4 and 24 streams both gave 875 Mbps upload, against 889 Mbps from iperf3. A pinned count of 16 recovers a lot on a poor path and changes nothing on a good one. It also costs almost no CPU — a container limited to one core still reached line rate with 24 streams.

Two smaller faults go with it. Ookla reports the same distance for every server in a city, so choosing "the nearest" resolved an arbitrary tie: the lucky server gave 710 Mbps and the unlucky one 587. The choice now goes to the lowest measured latency among the closest servers. The runner also shared one speedtest-go client across all tests with no lock, so a scheduled test that overlapped a manual one recorded 0 Mbps. Tests now queue. Stored history will show a step up after this change, mostly in upload, and mostly on hosts with fewer than eight cores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Speed tests now run more consistently with parallel connections and serialized concurrent requests.
  * Nearby test servers are selected using latency and distance, while avoiding unsuitable distant servers.
  * Test state is reset between speed tests for more reliable results.
  * Canceled tests now stop promptly when another test is already running.

* **Tests**
  * Added coverage for server selection and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->