### PR TITLE
fix(agent): show the vnstat error instead of exit status 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,8 @@ Common interface names:
 
 To monitor a physical interface of the host instead of a VPN tunnel, give the agent and `vnstat` the host network. Both must see the same interface, and both must use the same `vnstat` database.
 
+This example is for Linux. On Docker Desktop, the host network gives the network of the Docker virtual machine, not the physical interface of the computer.
+
 <details>
 <summary>Host Interface Compose Example</summary>
 
@@ -638,21 +640,18 @@ services:
       - netronome
 
   # The agent needs the host network to see the host interfaces.
-  # With the host network, Docker ignores a "ports" entry.
+  # Do not add a "ports" entry. It is not compatible with the host network.
   netronome-agent:
     image: ghcr.io/autobrr/netronome:latest
     container_name: netronome-agent
     network_mode: host
     environment:
-      - NETRONOME__AGENT_API_KEY=<apikey>
+      - NETRONOME__AGENT_API_KEY=${NETRONOME_AGENT_API_KEY}
     command:
       - agent
       - --interface
       - <interface>
-      - --disk-include
-      - /<pool>
     volumes:
-      - /:/hostfs
       - ./netronome/vnstat:/var/lib/vnstat
     restart: unless-stopped
 
@@ -679,6 +678,12 @@ networks:
 The agent is on the host network, but the dashboard is on a bridge network. The dashboard therefore cannot find the agent by container name. Add the agent with the IP address of the host, such as `http://192.168.1.10:8200`.
 
 Give the API key to the agent with `NETRONOME__AGENT_API_KEY`, not with the `--api-key` flag. A command line is visible to all users of the host, in `docker inspect` and in the process list.
+
+Keep the key out of the compose file. Put it in a `.env` file next to the compose file, and keep that file out of Git:
+
+```sh
+NETRONOME_AGENT_API_KEY=your-key-here
+```
 
 #### Missing Interfaces
 

--- a/README.md
+++ b/README.md
@@ -611,6 +611,20 @@ Common interface names:
 * `tun0` - OpenVPN or Gluetun custom provider
 * `wg0` - WireGuard
 
+#### Missing Interfaces
+
+`vnstat` records only the interfaces in its database. It does not add an interface that appeared after it made the database, or that was down at that time. The agent then shows no bandwidth data for that interface. The agent log shows `No interface matching "eth1" found in database`.
+
+Show which interfaces `vnstat` records. Then add the missing interface:
+
+```sh
+docker exec vnstat vnstat            # interfaces in the database
+docker exec vnstat vnstat --iflist   # interfaces the container can see
+docker exec vnstat vnstat --add -i eth1
+```
+
+If the interface is not in `--iflist`, the container cannot see it. Put the agent and `vnstat` in the same network namespace as the interface.
+
 #### Limiting Monitored Interfaces
 
 By default, `vnstat` will monitor all detected interfaces (e.g., eth0 and tun0). To monitor only the VPN tunnel:

--- a/README.md
+++ b/README.md
@@ -682,7 +682,9 @@ Give the API key to the agent with `NETRONOME__AGENT_API_KEY`, not with the `--a
 
 #### Missing Interfaces
 
-`vnstat` records only the interfaces in its database. It does not add an interface that appeared after it made the database, or that was down at that time. The agent then shows no bandwidth data for that interface. The agent log shows `No interface matching "eth1" found in database`.
+`vnstat` records only the interfaces in its database. The default of `AlwaysAddNewInterfaces` is 0, so the daemon does not add an interface that appears later. The `vergoh/vnstat` image registers the interfaces only when it creates the database. An interface that was down or absent at that moment stays unrecorded.
+
+The agent then shows no bandwidth data for that interface. The agent log shows `No interface matching "eth1" found in database`.
 
 Show which interfaces `vnstat` records. Then add the missing interface:
 
@@ -691,6 +693,10 @@ docker exec vnstat vnstat            # interfaces in the database
 docker exec vnstat vnstat --iflist   # interfaces the container can see
 docker exec vnstat vnstat --add -i eth1
 ```
+
+The daemon reads the new interface at its next save, because `RescanDatabaseOnSave` is enabled by default. This takes up to 5 minutes (`SaveInterval`), or up to 30 minutes when the interface is down (`OfflineSaveInterval`). To apply it at once, restart the container.
+
+To record every new interface without this step, set `AlwaysAddNewInterfaces 1` in `/etc/vnstat.conf`.
 
 If the interface is not in `--iflist`, the container cannot see it. Put the agent and `vnstat` in the same network namespace as the interface.
 

--- a/README.md
+++ b/README.md
@@ -611,6 +611,75 @@ Common interface names:
 * `tun0` - OpenVPN or Gluetun custom provider
 * `wg0` - WireGuard
 
+#### Monitoring a Host Interface
+
+To monitor a physical interface of the host instead of a VPN tunnel, give the agent and `vnstat` the host network. Both must see the same interface, and both must use the same `vnstat` database.
+
+<details>
+<summary>Host Interface Compose Example</summary>
+
+```yml
+services:
+  netronome:
+    image: ghcr.io/autobrr/netronome:latest
+    container_name: netronome
+    command: ["serve"]
+    environment:
+      - NETRONOME__HOST=0.0.0.0
+      - NETRONOME__PORT=7575
+      - TZ=UTC
+    ports:
+      - "7575:7575"
+    volumes:
+      - ./netronome/config:/config
+      - ./netronome/data:/data
+    restart: unless-stopped
+    networks:
+      - netronome
+
+  # The agent needs the host network to see the host interfaces.
+  # With the host network, Docker ignores a "ports" entry.
+  netronome-agent:
+    image: ghcr.io/autobrr/netronome:latest
+    container_name: netronome-agent
+    network_mode: host
+    environment:
+      - NETRONOME__AGENT_API_KEY=<apikey>
+    command:
+      - agent
+      - --interface
+      - <interface>
+      - --disk-include
+      - /<pool>
+    volumes:
+      - /:/hostfs
+      - ./netronome/vnstat:/var/lib/vnstat
+    restart: unless-stopped
+
+  vnstat:
+    image: ghcr.io/vergoh/vnstat
+    container_name: vnstat
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      - VNSTAT_Interfaces=<interface>
+      - TZ=UTC
+    volumes:
+      - ./netronome/vnstat:/var/lib/vnstat
+    restart: unless-stopped
+
+networks:
+  netronome:
+    driver: bridge
+```
+</details>
+
+The agent is on the host network, but the dashboard is on a bridge network. The dashboard therefore cannot find the agent by container name. Add the agent with the IP address of the host, such as `http://192.168.1.10:8200`.
+
+Give the API key to the agent with `NETRONOME__AGENT_API_KEY`, not with the `--api-key` flag. A command line is visible to all users of the host, in `docker inspect` and in the process list.
+
 #### Missing Interfaces
 
 `vnstat` records only the interfaces in its database. It does not add an interface that appeared after it made the database, or that was down at that time. The agent then shows no bandwidth data for that interface. The agent log shows `No interface matching "eth1" found in database`.

--- a/internal/agent/bandwidth.go
+++ b/internal/agent/bandwidth.go
@@ -5,11 +5,13 @@ package agent
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -34,10 +36,12 @@ func (a *Agent) handleHistoricalExport(c *gin.Context) {
 	cmd := exec.Command("vnstat", args...)
 	output, err := cmd.Output()
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to export historical data")
+		// vnstat writes errors to stdout, so err alone is only "exit status 1".
+		details := cmp.Or(strings.TrimSpace(string(output)), err.Error())
+		log.Error().Err(err).Str("vnstat_output", details).Str("interface", iface).Msg("Failed to export historical data")
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "failed to export historical data",
-			"details": err.Error(),
+			"details": details,
 		})
 		return
 	}
@@ -111,7 +115,8 @@ func (a *Agent) runBandwidthMonitor(ctx context.Context) {
 		// Parse JSON to validate it
 		var data MonitorLiveData
 		if err := json.Unmarshal([]byte(line), &data); err != nil {
-			log.Warn().Err(err).Str("line", line).Msg("Failed to parse bandwidth data JSON")
+			// vnstat writes errors to stdout, so this line is usually the reason.
+			log.Warn().Str("vnstat_output", line).Str("interface", a.config.Interface).Msg("Unexpected vnstat output, expected JSON")
 			continue
 		}
 
@@ -146,7 +151,7 @@ func (a *Agent) runBandwidthMonitor(ctx context.Context) {
 	}
 
 	if err := cmd.Wait(); err != nil {
-		log.Error().Err(err).Msg("vnstat command failed")
+		log.Error().Err(err).Str("interface", a.config.Interface).Msg("vnstat command failed")
 	}
 }
 

--- a/internal/agent/bandwidth.go
+++ b/internal/agent/bandwidth.go
@@ -37,11 +37,11 @@ func (a *Agent) handleHistoricalExport(c *gin.Context) {
 	output, err := cmd.Output()
 	if err != nil {
 		// vnstat writes errors to stdout, so err alone is only "exit status 1".
-		details := cmp.Or(strings.TrimSpace(string(output)), err.Error())
-		log.Error().Err(err).Str("vnstat_output", details).Str("interface", iface).Msg("Failed to export historical data")
+		vnstatOutput := strings.TrimSpace(string(output))
+		log.Error().Err(err).Str("vnstat_output", vnstatOutput).Str("interface", iface).Msg("Failed to export historical data")
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "failed to export historical data",
-			"details": details,
+			"details": cmp.Or(vnstatOutput, err.Error()),
 		})
 		return
 	}

--- a/internal/agent/bandwidth.go
+++ b/internal/agent/bandwidth.go
@@ -116,7 +116,7 @@ func (a *Agent) runBandwidthMonitor(ctx context.Context) {
 		var data MonitorLiveData
 		if err := json.Unmarshal([]byte(line), &data); err != nil {
 			// vnstat writes errors to stdout, so this line is usually the reason.
-			log.Warn().Str("vnstat_output", line).Str("interface", a.config.Interface).Msg("Unexpected vnstat output, expected JSON")
+			log.Warn().Err(err).Str("vnstat_output", line).Str("interface", a.config.Interface).Msg("Unexpected vnstat output, expected JSON")
 			continue
 		}
 


### PR DESCRIPTION
The agent runs the `vnstat` CLI. vnstat writes its errors to stdout and exits 1, but the historical export discarded that output. The log and the API therefore reported only `exit status 1`, and the real reason was lost. One reason is an interface that is missing from the vnstat database, which a user had to find without help. The agent now logs the vnstat text and returns it in the error details, for example `Error: No interface matching "eth9" found in database.`

The README gets two new sections. The first covers the missing interface, with the `vnstat --add` command and the `--iflist` check that shows whether the container can see the interface at all. The second adds a compose example for a host interface, because the only Docker agent example was for a VPN container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Docker deployment guidance for monitoring host network interfaces.
  * Documented host networking, shared bandwidth data storage, dashboard connectivity, API-key configuration, and troubleshooting missing interfaces.

* **Bug Fixes**
  * Improved bandwidth monitoring error details by showing clearer command output when historical data cannot be exported.
  * Enhanced monitoring warnings and failure logs with the affected network interface and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->