### PR TITLE
chore(deps): do not offer typescript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,9 @@ updates:
       npm:
         patterns:
           - "*"
+    ignore:
+      # TypeScript 7.0 ships no JavaScript API, so typescript-eslint cannot
+      # load and `pnpm lint` fails. Remove this after typescript-eslint adds
+      # support for TypeScript 7.1 (typescript-eslint#10940).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Stops dependabot from putting a TypeScript major bump into the monthly npm group.

TypeScript 7.0 ships no JavaScript API, so `@typescript-eslint/parser` throws at load and `pnpm lint` fails before it reads a file. No eslint config change avoids it. Found in #260, which bumped `typescript` from 6.0.3 to 7.0.2.

Remove this rule after typescript-eslint adds TypeScript 7.1 support (typescript-eslint/typescript-eslint#10940).

## How has this been tested?

Installed the #260 branch with TypeScript 7.0.2 and ran `pnpm lint`: it exits 2 with `typescript-eslint does not support TS 7.0` and lints nothing. With `typescript` back on 6.0.3 it runs again. `pnpm tsc --noEmit` passes on both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to defer major TypeScript upgrades.
  * This helps avoid incompatible updates until ecosystem support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->