### PR TITLE
chore(deps): keep npm major updates out of the monthly group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,9 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Major updates go into the group with everything else, so a breaking
-      # change arrives in a routine monthly bump. Do them one at a time
-      # instead. Use `pnpm outdated` to see which majors are available.
+      # Do not offer npm major updates. The group matches all packages, so a
+      # major update would arrive with the routine monthly minor and patch
+      # bumps. Do majors by hand, one at a time. Use `pnpm outdated` to see
+      # which majors are available.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,8 @@ updates:
         patterns:
           - "*"
     ignore:
-      # TypeScript 7.0 ships no JavaScript API, so typescript-eslint cannot
-      # load and `pnpm lint` fails. Remove this after typescript-eslint adds
-      # support for TypeScript 7.1 (typescript-eslint#10940).
-      - dependency-name: "typescript"
+      # Major updates go into the group with everything else, so a breaking
+      # change arrives in a routine monthly bump. Do them one at a time
+      # instead. Use `pnpm outdated` to see which majors are available.
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Widens the ignore rule from #264 to all npm majors.

The npm group matches `*`, so a major update arrives in the same PR as routine minor and patch bumps. The August group had three: `typescript` 6 to 7, `@tanstack/react-table` 8 to 9, and `motion` 12 to 13. #264 stopped the first. The other two came back in #266, where `@tanstack/react-table` 9 fails the build — it no longer exports `useReactTable`, `getCoreRowModel`, `getFilteredRowModel`, `getPaginationRowModel`, or `getSortedRowModel`, which `web/src/components/ui/data-table.tsx` needs.

Minor and patch updates continue as before. Do major updates one at a time, and use `pnpm outdated` to see which are available.

Not applied to the Go group: a Go module with a major version above 1 has a different import path, so dependabot cannot bump one without a code change.

## How has this been tested?

Confirmed the failure this prevents: `Build web` on #266 fails with five `MISSING_EXPORT` errors from `@tanstack/react-table@9.2.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to exclude all major-version upgrades from routine monthly updates.
  * Routine updates will continue to include minor and patch releases.
  * Major upgrades can be reviewed and applied individually when appropriate, using the project’s dependency review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->