### PR TITLE
feat(dns): add DNS monitor backend

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,13 @@ agent as the server stores it, not a monitor in the packet loss sense.
 **Bandwidth** — the interface counters that an agent reads with `vnstat`. This is
 the traffic that the machine passes. It is not a speed test.
 
+**DNS monitor** (`DNSMonitor`) — a resolver, an interval, a query, and a protocol
+(UDP, TCP, or DoT). The server sends the query to the resolver and records the
+response time and the response code. A check fails on a timeout or an error
+response code. Its states are the normal state, `down`, and `recovered`. The DNS
+monitor measures the resolver, not the record. It does not check that an answer
+is correct.
+
 ## Notifications
 
 Four tables, and the relation between them is the design:

--- a/cmd/netronome/main.go
+++ b/cmd/netronome/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/autobrr/netronome/internal/agent"
 	"github.com/autobrr/netronome/internal/config"
 	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/dnsmonitor"
 	"github.com/autobrr/netronome/internal/logger"
 	"github.com/autobrr/netronome/internal/monitor"
 	"github.com/autobrr/netronome/internal/notifications"
@@ -289,16 +290,20 @@ func runServer(cmd *cobra.Command, args []string) error {
 	// Create monitor service variable
 	var monitorService *monitor.Service
 
+	// DNS monitors need no configuration, the schedule lives per monitor
+	dnsService := dnsmonitor.NewService(db, notifier)
+
 	// Now create scheduler with packet loss service
-	schedulerSvc := scheduler.New(db, speedtestSvc, packetLossService, notifier)
+	schedulerSvc := scheduler.New(db, speedtestSvc, packetLossService, dnsService, notifier)
 
 	// create server handler with packet loss service and monitor service
-	serverHandler := server.NewServer(speedtestSvc, db, schedulerSvc, cfg, packetLossService, monitorService, notifier, licenseService)
+	serverHandler := server.NewServer(speedtestSvc, db, schedulerSvc, cfg, packetLossService, dnsService, monitorService, notifier, licenseService)
 	updateChecker := update.New(cfg.CheckForUpdates, appversion.Version, nil)
 	serverHandler.SetUpdateChecker(updateChecker)
 
 	speedtestSvc.SetBroadcastUpdate(serverHandler.BroadcastUpdate)
 	speedtestSvc.SetBroadcastTracerouteUpdate(serverHandler.BroadcastTracerouteUpdate)
+	dnsService.SetBroadcast(serverHandler.BroadcastDNSUpdate)
 
 	// Set the broadcaster for packet loss service
 	if packetLossService != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/keygen-sh/machineid v1.1.3
 	github.com/lib/pq v1.12.3
+	github.com/miekg/dns v1.1.73
 	github.com/nicholas-fedor/shoutrrr v0.18.0
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
-github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
-github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
+github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=
+github.com/miekg/dns v1.1.73/go.mod h1:RW2Obtfd5NZHvOFe3zYG0W8koWOQtAzyHaLo8vASBuQ=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -99,6 +99,7 @@ type Service interface {
 	GetDNSMonitor(monitorID int64) (*types.DNSMonitor, error)
 	GetDNSMonitors() ([]*types.DNSMonitor, error)
 	UpdateDNSMonitor(monitor *types.DNSMonitor) error
+	UpdateDNSMonitorSchedule(monitorID int64, lastRun *time.Time, nextRun time.Time) error
 	UpdateDNSMonitorState(monitorID int64, state string) error
 	DeleteDNSMonitor(monitorID int64) error
 	SaveDNSResult(result *types.DNSResult) error

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -94,6 +94,17 @@ type Service interface {
 	GetPacketLossResultDetail(monitorID int64, resultID int64) (*types.PacketLossResult, error)
 	UpdatePacketLossMonitorState(monitorID int64, state string) error
 
+	// DNS monitor operations
+	CreateDNSMonitor(monitor *types.DNSMonitor) (*types.DNSMonitor, error)
+	GetDNSMonitor(monitorID int64) (*types.DNSMonitor, error)
+	GetDNSMonitors() ([]*types.DNSMonitor, error)
+	UpdateDNSMonitor(monitor *types.DNSMonitor) error
+	UpdateDNSMonitorState(monitorID int64, state string) error
+	DeleteDNSMonitor(monitorID int64) error
+	SaveDNSResult(result *types.DNSResult) error
+	GetLatestDNSResult(monitorID int64) (*types.DNSResult, error)
+	GetDNSResults(monitorID int64, page int, limit int) (*types.PaginatedDNSResults, error)
+
 	// Monitor operations
 	CreateMonitorAgent(ctx context.Context, agent *types.MonitorAgent) (*types.MonitorAgent, error)
 	GetMonitorAgent(ctx context.Context, agentID int64) (*types.MonitorAgent, error)
@@ -118,7 +129,7 @@ type Service interface {
 	GetMonitorLatestSnapshot(ctx context.Context, agentID int64, periodType string) (*types.MonitorHistoricalSnapshot, error)
 
 	CleanupMonitorData(ctx context.Context) error
-	PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, err error)
+	PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, dnsResults int64, err error)
 
 	// Embed NotificationService interface
 	NotificationService

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -183,6 +183,8 @@ var testTablesToClear = []string{
 	"app_settings",
 	"packet_loss_results",
 	"packet_loss_monitors",
+	"dns_results",
+	"dns_monitors",
 	"monitor_historical_snapshots",
 	"monitor_resource_stats",
 	"monitor_peak_stats",
@@ -427,6 +429,28 @@ func CreateTestPacketLossMonitor(t *testing.T, td *TestDatabase) *types.PacketLo
 	}
 
 	result, err := td.Service.CreatePacketLossMonitor(monitor)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, result.ID, int64(0))
+
+	return result
+}
+
+// CreateTestDNSMonitor creates a test DNS monitor
+func CreateTestDNSMonitor(t *testing.T, td *TestDatabase) *types.DNSMonitor {
+	t.Helper()
+
+	monitor := &types.DNSMonitor{
+		Name:       "Test DNS Monitor",
+		Host:       "127.0.0.1:5353",
+		Protocol:   types.DNSProtocolUDP,
+		Query:      "example.invalid",
+		RecordType: "A",
+		Interval:   "60s",
+		Enabled:    true,
+	}
+
+	result, err := td.Service.CreateDNSMonitor(monitor)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Greater(t, result.ID, int64(0))

--- a/internal/database/dns.go
+++ b/internal/database/dns.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/netronome/internal/config"
+	"github.com/autobrr/netronome/internal/types"
+)
+
+var dnsMonitorColumns = []string{
+	"id", "host", "name", "protocol", "query", "record_type", "interval", "enabled",
+	"last_run", "next_run", "last_state", "last_state_change", "created_at", "updated_at",
+}
+
+func scanDNSMonitor(scan func(dest ...any) error) (*types.DNSMonitor, error) {
+	monitor := &types.DNSMonitor{}
+	err := scan(
+		&monitor.ID,
+		&monitor.Host,
+		&monitor.Name,
+		&monitor.Protocol,
+		&monitor.Query,
+		&monitor.RecordType,
+		&monitor.Interval,
+		&monitor.Enabled,
+		&monitor.LastRun,
+		&monitor.NextRun,
+		&monitor.LastState,
+		&monitor.LastStateChange,
+		&monitor.CreatedAt,
+		&monitor.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return monitor, nil
+}
+
+// CreateDNSMonitor creates a new DNS monitor
+func (s *service) CreateDNSMonitor(monitor *types.DNSMonitor) (*types.DNSMonitor, error) {
+	monitor.CreatedAt = time.Now()
+	monitor.UpdatedAt = time.Now()
+
+	query := s.sqlBuilder.
+		Insert("dns_monitors").
+		Columns("host", "name", "protocol", "query", "record_type", "interval", "enabled", "next_run", "created_at", "updated_at").
+		Values(monitor.Host, monitor.Name, monitor.Protocol, monitor.Query, monitor.RecordType, monitor.Interval, monitor.Enabled, monitor.NextRun, monitor.CreatedAt, monitor.UpdatedAt)
+
+	if s.config.Type == config.Postgres {
+		query = query.Suffix("RETURNING id")
+		if err := query.RunWith(s.db).QueryRow().Scan(&monitor.ID); err != nil {
+			return nil, fmt.Errorf("failed to create dns monitor: %w", err)
+		}
+		return monitor, nil
+	}
+
+	res, err := query.RunWith(s.db).Exec()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dns monitor: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last insert ID: %w", err)
+	}
+	monitor.ID = id
+
+	return monitor, nil
+}
+
+// GetDNSMonitor retrieves a DNS monitor by ID
+func (s *service) GetDNSMonitor(monitorID int64) (*types.DNSMonitor, error) {
+	query := s.sqlBuilder.
+		Select(dnsMonitorColumns...).
+		From("dns_monitors").
+		Where(sq.Eq{"id": monitorID})
+
+	monitor, err := scanDNSMonitor(query.RunWith(s.db).QueryRow().Scan)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dns monitor: %w", err)
+	}
+
+	return monitor, nil
+}
+
+// GetDNSMonitors retrieves all DNS monitors
+func (s *service) GetDNSMonitors() ([]*types.DNSMonitor, error) {
+	query := s.sqlBuilder.
+		Select(dnsMonitorColumns...).
+		From("dns_monitors").
+		OrderBy("created_at DESC")
+
+	rows, err := query.RunWith(s.db).Query()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dns monitors: %w", err)
+	}
+	defer rows.Close()
+
+	var monitors []*types.DNSMonitor
+	for rows.Next() {
+		monitor, err := scanDNSMonitor(rows.Scan)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to scan dns monitor")
+			continue
+		}
+		monitors = append(monitors, monitor)
+	}
+
+	return monitors, rows.Err()
+}
+
+// UpdateDNSMonitor updates an existing DNS monitor
+func (s *service) UpdateDNSMonitor(monitor *types.DNSMonitor) error {
+	monitor.UpdatedAt = time.Now()
+
+	query := s.sqlBuilder.
+		Update("dns_monitors").
+		SetMap(map[string]interface{}{
+			"host":        monitor.Host,
+			"name":        monitor.Name,
+			"protocol":    monitor.Protocol,
+			"query":       monitor.Query,
+			"record_type": monitor.RecordType,
+			"interval":    monitor.Interval,
+			"enabled":     monitor.Enabled,
+			"last_run":    monitor.LastRun,
+			"next_run":    monitor.NextRun,
+			"updated_at":  monitor.UpdatedAt,
+		}).
+		Where(sq.Eq{"id": monitor.ID})
+
+	res, err := query.RunWith(s.db).Exec()
+	if err != nil {
+		return fmt.Errorf("failed to update dns monitor: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// UpdateDNSMonitorState updates the monitor state and timestamp
+func (s *service) UpdateDNSMonitorState(monitorID int64, state string) error {
+	query := s.sqlBuilder.
+		Update("dns_monitors").
+		Set("last_state", state).
+		Set("last_state_change", time.Now()).
+		Where(sq.Eq{"id": monitorID})
+
+	res, err := query.RunWith(s.db).Exec()
+	if err != nil {
+		return fmt.Errorf("failed to update dns monitor state: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// DeleteDNSMonitor deletes a DNS monitor and its results
+func (s *service) DeleteDNSMonitor(monitorID int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// delete results first, SQLite only enforces the cascade with foreign keys on
+	if _, err := s.sqlBuilder.Delete("dns_results").Where(sq.Eq{"monitor_id": monitorID}).RunWith(tx).Exec(); err != nil {
+		return fmt.Errorf("failed to delete dns results: %w", err)
+	}
+
+	res, err := s.sqlBuilder.Delete("dns_monitors").Where(sq.Eq{"id": monitorID}).RunWith(tx).Exec()
+	if err != nil {
+		return fmt.Errorf("failed to delete dns monitor: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	return tx.Commit()
+}
+
+// SaveDNSResult saves a DNS check result
+func (s *service) SaveDNSResult(result *types.DNSResult) error {
+	query := s.sqlBuilder.
+		Insert("dns_results").
+		Columns("monitor_id", "response_time_ms", "response_code", "success", "error", "created_at").
+		Values(result.MonitorID, result.ResponseTimeMs, result.ResponseCode, result.Success, result.Error, result.CreatedAt)
+
+	if s.config.Type == config.Postgres {
+		query = query.Suffix("RETURNING id")
+		if err := query.RunWith(s.db).QueryRow().Scan(&result.ID); err != nil {
+			return fmt.Errorf("failed to save dns result: %w", err)
+		}
+		return nil
+	}
+
+	res, err := query.RunWith(s.db).Exec()
+	if err != nil {
+		return fmt.Errorf("failed to save dns result: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("failed to get last insert ID: %w", err)
+	}
+	result.ID = id
+
+	return nil
+}
+
+// GetLatestDNSResult retrieves the most recent result for a monitor
+func (s *service) GetLatestDNSResult(monitorID int64) (*types.DNSResult, error) {
+	query := s.sqlBuilder.
+		Select("id", "monitor_id", "response_time_ms", "response_code", "success", "error", "created_at").
+		From("dns_results").
+		Where(sq.Eq{"monitor_id": monitorID}).
+		OrderBy("created_at DESC", "id DESC").
+		Limit(1)
+
+	result := &types.DNSResult{}
+	err := query.RunWith(s.db).QueryRow().Scan(
+		&result.ID,
+		&result.MonitorID,
+		&result.ResponseTimeMs,
+		&result.ResponseCode,
+		&result.Success,
+		&result.Error,
+		&result.CreatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest dns result: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetDNSResults retrieves paginated results for a monitor
+func (s *service) GetDNSResults(monitorID int64, page int, limit int) (*types.PaginatedDNSResults, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	countQuery := s.sqlBuilder.
+		Select("COUNT(*)").
+		From("dns_results").
+		Where(sq.Eq{"monitor_id": monitorID})
+
+	var total int
+	if err := countQuery.RunWith(s.db).QueryRow().Scan(&total); err != nil {
+		return nil, fmt.Errorf("failed to count dns results: %w", err)
+	}
+
+	query := s.sqlBuilder.
+		Select("id", "monitor_id", "response_time_ms", "response_code", "success", "error", "created_at").
+		From("dns_results").
+		Where(sq.Eq{"monitor_id": monitorID}).
+		OrderBy("created_at DESC", "id DESC").
+		Limit(uint64(limit)).
+		Offset(uint64((page - 1) * limit))
+
+	rows, err := query.RunWith(s.db).Query()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dns results: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]types.DNSResult, 0, limit)
+	for rows.Next() {
+		var result types.DNSResult
+		err := rows.Scan(
+			&result.ID,
+			&result.MonitorID,
+			&result.ResponseTimeMs,
+			&result.ResponseCode,
+			&result.Success,
+			&result.Error,
+			&result.CreatedAt,
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to scan dns result")
+			continue
+		}
+		results = append(results, result)
+	}
+
+	return &types.PaginatedDNSResults{
+		Data:  results,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}, rows.Err()
+}

--- a/internal/database/dns.go
+++ b/internal/database/dns.go
@@ -155,6 +155,32 @@ func (s *service) UpdateDNSMonitor(monitor *types.DNSMonitor) error {
 	return nil
 }
 
+// UpdateDNSMonitorSchedule writes only the run times. The scheduler holds a
+// monitor it read one tick ago, so a full row write there would put the stale
+// configuration back over an edit the user made while the check ran.
+func (s *service) UpdateDNSMonitorSchedule(monitorID int64, lastRun *time.Time, nextRun time.Time) error {
+	query := s.sqlBuilder.
+		Update("dns_monitors").
+		Set("last_run", lastRun).
+		Set("next_run", nextRun).
+		Where(sq.Eq{"id": monitorID})
+
+	res, err := query.RunWith(s.db).Exec()
+	if err != nil {
+		return fmt.Errorf("failed to update dns monitor schedule: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
 // UpdateDNSMonitorState updates the monitor state and timestamp
 func (s *service) UpdateDNSMonitorState(monitorID int64, state string) error {
 	query := s.sqlBuilder.

--- a/internal/database/dns_integration_test.go
+++ b/internal/database/dns_integration_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+func TestDNSMonitor_CRUD(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		created, err := td.Service.CreateDNSMonitor(&types.DNSMonitor{
+			Name:       "Router",
+			Host:       "192.168.1.1",
+			Protocol:   types.DNSProtocolUDP,
+			Query:      "google.com",
+			RecordType: "A",
+			Interval:   "60s",
+			Enabled:    true,
+		})
+		require.NoError(t, err)
+		assert.Greater(t, created.ID, int64(0))
+
+		retrieved, err := td.Service.GetDNSMonitor(created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Router", retrieved.Name)
+		assert.Equal(t, "192.168.1.1", retrieved.Host)
+		assert.Equal(t, types.DNSProtocolUDP, retrieved.Protocol)
+		assert.Equal(t, "google.com", retrieved.Query)
+		assert.Equal(t, "A", retrieved.RecordType)
+		assert.True(t, retrieved.Enabled)
+
+		retrieved.Name = "Pi-hole"
+		retrieved.Protocol = types.DNSProtocolDoT
+		retrieved.RecordType = "AAAA"
+		retrieved.Enabled = false
+		require.NoError(t, td.Service.UpdateDNSMonitor(retrieved))
+
+		updated, err := td.Service.GetDNSMonitor(created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Pi-hole", updated.Name)
+		assert.Equal(t, types.DNSProtocolDoT, updated.Protocol)
+		assert.Equal(t, "AAAA", updated.RecordType)
+		assert.False(t, updated.Enabled)
+
+		monitors, err := td.Service.GetDNSMonitors()
+		require.NoError(t, err)
+		assert.Len(t, monitors, 1)
+
+		require.NoError(t, td.Service.DeleteDNSMonitor(created.ID))
+
+		_, err = td.Service.GetDNSMonitor(created.ID)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestDNSMonitor_NotFound(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		_, err := td.Service.GetDNSMonitor(99999)
+		assert.ErrorIs(t, err, ErrNotFound)
+
+		assert.ErrorIs(t, td.Service.UpdateDNSMonitorState(99999, "down"), ErrNotFound)
+		assert.ErrorIs(t, td.Service.DeleteDNSMonitor(99999), ErrNotFound)
+	})
+}
+
+func TestUpdateDNSMonitorState(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestDNSMonitor(t, td)
+
+		require.NoError(t, td.Service.UpdateDNSMonitorState(monitor.ID, "down"))
+
+		updated, err := td.Service.GetDNSMonitor(monitor.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "down", updated.LastState)
+		assert.NotNil(t, updated.LastStateChange)
+	})
+}
+
+func TestDNSResults_SaveAndLatest(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestDNSMonitor(t, td)
+
+		errText := "read udp 127.0.0.1:5353: i/o timeout"
+		results := []types.DNSResult{
+			{MonitorID: monitor.ID, ResponseTimeMs: 12.5, ResponseCode: "NOERROR", Success: true, CreatedAt: time.Now().Add(-2 * time.Hour)},
+			{MonitorID: monitor.ID, ResponseTimeMs: 5000, ResponseCode: "", Success: false, Error: &errText, CreatedAt: time.Now().Add(-time.Hour)},
+			{MonitorID: monitor.ID, ResponseTimeMs: 9.25, ResponseCode: "NOERROR", Success: true, CreatedAt: time.Now()},
+		}
+
+		for i := range results {
+			require.NoError(t, td.Service.SaveDNSResult(&results[i]))
+			assert.Greater(t, results[i].ID, int64(0))
+		}
+
+		latest, err := td.Service.GetLatestDNSResult(monitor.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 9.25, latest.ResponseTimeMs)
+		assert.True(t, latest.Success)
+		assert.Nil(t, latest.Error)
+
+		page, err := td.Service.GetDNSResults(monitor.ID, 1, 2)
+		require.NoError(t, err)
+		require.Len(t, page.Data, 2)
+		assert.Equal(t, 3, page.Total)
+		assert.Equal(t, 1, page.Page)
+		assert.Equal(t, 2, page.Limit)
+		require.NotNil(t, page.Data[1].Error)
+		assert.Equal(t, errText, *page.Data[1].Error)
+
+		second, err := td.Service.GetDNSResults(monitor.ID, 2, 2)
+		require.NoError(t, err)
+		require.Len(t, second.Data, 1)
+		assert.NotEqual(t, page.Data[0].ID, second.Data[0].ID)
+		assert.NotEqual(t, page.Data[1].ID, second.Data[0].ID)
+	})
+}
+
+func TestDeleteDNSMonitor_RemovesResults(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestDNSMonitor(t, td)
+
+		result := &types.DNSResult{MonitorID: monitor.ID, ResponseTimeMs: 11, ResponseCode: "NOERROR", Success: true, CreatedAt: time.Now()}
+		require.NoError(t, td.Service.SaveDNSResult(result))
+
+		require.NoError(t, td.Service.DeleteDNSMonitor(monitor.ID))
+		AssertRecordNotExists(t, td, "dns_results", "monitor_id", monitor.ID)
+	})
+}
+
+func TestDNSNotificationEventsSeeded(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		events, err := td.Service.GetEventsByCategory(NotificationCategoryDNS)
+		require.NoError(t, err)
+		require.Len(t, events, 2)
+
+		types := []string{events[0].EventType, events[1].EventType}
+		assert.Contains(t, types, NotificationEventDNSDown)
+		assert.Contains(t, types, NotificationEventDNSRecovered)
+	})
+}

--- a/internal/database/dns_integration_test.go
+++ b/internal/database/dns_integration_test.go
@@ -83,6 +83,33 @@ func TestUpdateDNSMonitorState(t *testing.T) {
 	})
 }
 
+func TestUpdateDNSMonitorSchedule_KeepsConfiguration(t *testing.T) {
+	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
+		monitor := CreateTestDNSMonitor(t, td)
+
+		lastRun := time.Now().UTC().Truncate(time.Second)
+		nextRun := lastRun.Add(time.Minute)
+		require.NoError(t, td.Service.UpdateDNSMonitorSchedule(monitor.ID, &lastRun, nextRun))
+
+		updated, err := td.Service.GetDNSMonitor(monitor.ID)
+		require.NoError(t, err)
+		require.NotNil(t, updated.LastRun)
+		require.NotNil(t, updated.NextRun)
+		assert.Equal(t, lastRun, updated.LastRun.UTC())
+		assert.Equal(t, nextRun, updated.NextRun.UTC())
+
+		// the configuration the user owns is untouched
+		assert.Equal(t, monitor.Host, updated.Host)
+		assert.Equal(t, monitor.Protocol, updated.Protocol)
+		assert.Equal(t, monitor.Query, updated.Query)
+		assert.Equal(t, monitor.RecordType, updated.RecordType)
+		assert.Equal(t, monitor.Interval, updated.Interval)
+		assert.Equal(t, monitor.Enabled, updated.Enabled)
+
+		assert.ErrorIs(t, td.Service.UpdateDNSMonitorSchedule(99999, &lastRun, nextRun), ErrNotFound)
+	})
+}
+
 func TestDNSResults_SaveAndLatest(t *testing.T) {
 	RunTestWithBothDatabases(t, func(t *testing.T, td *TestDatabase) {
 		monitor := CreateTestDNSMonitor(t, td)

--- a/internal/database/migrations/postgres/022_add_dns_monitoring_postgres.sql
+++ b/internal/database/migrations/postgres/022_add_dns_monitoring_postgres.sql
@@ -1,0 +1,40 @@
+-- Add DNS monitoring tables
+
+-- Table for storing DNS monitor configurations
+CREATE TABLE IF NOT EXISTS dns_monitors (
+    id SERIAL PRIMARY KEY,
+    host TEXT NOT NULL,                          -- resolver host, with an optional :port
+    name TEXT,
+    protocol TEXT NOT NULL DEFAULT 'udp',        -- udp, tcp, or dot
+    query TEXT NOT NULL DEFAULT 'google.com',    -- hostname to ask for
+    record_type TEXT NOT NULL DEFAULT 'A',
+    interval TEXT NOT NULL DEFAULT '60s',
+    enabled BOOLEAN DEFAULT true,
+    last_run TIMESTAMP WITH TIME ZONE,
+    next_run TIMESTAMP WITH TIME ZONE,
+    last_state TEXT DEFAULT 'unknown',
+    last_state_change TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table for storing DNS check results
+CREATE TABLE IF NOT EXISTS dns_results (
+    id SERIAL PRIMARY KEY,
+    monitor_id INTEGER NOT NULL,
+    response_time_ms DOUBLE PRECISION NOT NULL,
+    response_code TEXT NOT NULL DEFAULT '',      -- NOERROR, SERVFAIL, NXDOMAIN, and the like
+    success BOOLEAN NOT NULL,
+    error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (monitor_id) REFERENCES dns_monitors(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_dns_results_monitor_created_at ON dns_results(monitor_id, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_dns_results_created_at ON dns_results(created_at);
+
+-- DNS notification events
+INSERT INTO notification_events (category, event_type, name, description, supports_threshold, threshold_unit) VALUES
+('dns', 'monitor_down', 'DNS Monitor Down', 'DNS resolver did not answer or returned an error', false, NULL),
+('dns', 'monitor_recovered', 'DNS Monitor Recovered', 'Previously failing DNS resolver answers again', false, NULL)
+ON CONFLICT DO NOTHING;

--- a/internal/database/migrations/sqlite/022_add_dns_monitoring.sql
+++ b/internal/database/migrations/sqlite/022_add_dns_monitoring.sql
@@ -1,0 +1,39 @@
+-- Add DNS monitoring tables
+
+-- Table for storing DNS monitor configurations
+CREATE TABLE dns_monitors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    host TEXT NOT NULL,                          -- resolver host, with an optional :port
+    name TEXT,
+    protocol TEXT NOT NULL DEFAULT 'udp',        -- udp, tcp, or dot
+    query TEXT NOT NULL DEFAULT 'google.com',    -- hostname to ask for
+    record_type TEXT NOT NULL DEFAULT 'A',
+    interval TEXT NOT NULL DEFAULT '60s',
+    enabled BOOLEAN DEFAULT 1,
+    last_run TIMESTAMP,
+    next_run TIMESTAMP,
+    last_state TEXT DEFAULT 'unknown',
+    last_state_change TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table for storing DNS check results
+CREATE TABLE dns_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    monitor_id INTEGER NOT NULL,
+    response_time_ms REAL NOT NULL,
+    response_code TEXT NOT NULL DEFAULT '',      -- NOERROR, SERVFAIL, NXDOMAIN, and the like
+    success BOOLEAN NOT NULL,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (monitor_id) REFERENCES dns_monitors(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_dns_results_monitor_created_at ON dns_results(monitor_id, created_at DESC, id DESC);
+CREATE INDEX idx_dns_results_created_at ON dns_results(created_at);
+
+-- DNS notification events
+INSERT INTO notification_events (category, event_type, name, description, supports_threshold, threshold_unit) VALUES
+('dns', 'monitor_down', 'DNS Monitor Down', 'DNS resolver did not answer or returned an error', 0, NULL),
+('dns', 'monitor_recovered', 'DNS Monitor Recovered', 'Previously failing DNS resolver answers again', 0, NULL);

--- a/internal/database/notifications_types.go
+++ b/internal/database/notifications_types.go
@@ -72,6 +72,7 @@ const (
 	NotificationCategorySpeedtest  = "speedtest"
 	NotificationCategoryPacketLoss = "packetloss"
 	NotificationCategoryAgent      = "agent"
+	NotificationCategoryDNS        = "dns"
 )
 
 // NotificationEventType constants
@@ -87,6 +88,10 @@ const (
 	NotificationEventPacketLossHigh      = "threshold_exceeded"
 	NotificationEventPacketLossDown      = "monitor_down"
 	NotificationEventPacketLossRecovered = "monitor_recovered"
+
+	// DNS monitor events
+	NotificationEventDNSDown      = "monitor_down"
+	NotificationEventDNSRecovered = "monitor_recovered"
 
 	// Agent events
 	NotificationEventAgentOffline       = "offline"

--- a/internal/database/purge.go
+++ b/internal/database/purge.go
@@ -11,39 +11,46 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// PurgeHistoricalData deletes speed test and packet loss results older than the
-// given cutoff. On SQLite it runs VACUUM afterwards so the on-disk file actually
-// shrinks (VACUUM cannot run inside a transaction). A failed VACUUM is logged but
-// does not fail the call since the rows are already gone.
-func (s *service) PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, err error) {
+// PurgeHistoricalData deletes speed test, packet loss, and DNS results older
+// than the given cutoff. On SQLite it runs VACUUM afterwards so the on-disk file
+// actually shrinks (VACUUM cannot run inside a transaction). A failed VACUUM is
+// logged but does not fail the call since the rows are already gone.
+func (s *service) PurgeHistoricalData(ctx context.Context, before time.Time) (speedTests int64, packetLoss int64, dnsResults int64, err error) {
 	log.Info().Time("before", before).Msg("Purging historical data")
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	defer tx.Rollback()
 
 	stResult, err := s.sqlBuilder.Delete("speed_tests").Where(sq.Lt{"created_at": before}).RunWith(tx).ExecContext(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to purge speed tests")
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	speedTests, _ = stResult.RowsAffected()
 
 	plResult, err := s.sqlBuilder.Delete("packet_loss_results").Where(sq.Lt{"created_at": before}).RunWith(tx).ExecContext(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to purge packet loss results")
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	packetLoss, _ = plResult.RowsAffected()
 
+	dnsResult, err := s.sqlBuilder.Delete("dns_results").Where(sq.Lt{"created_at": before}).RunWith(tx).ExecContext(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to purge dns results")
+		return 0, 0, 0, err
+	}
+	dnsResults, _ = dnsResult.RowsAffected()
+
 	if err := tx.Commit(); err != nil {
 		log.Error().Err(err).Msg("Failed to commit purge transaction")
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 
-	log.Info().Int64("speed_tests", speedTests).Int64("packet_loss", packetLoss).Msg("Purged historical data")
+	log.Info().Int64("speed_tests", speedTests).Int64("packet_loss", packetLoss).Int64("dns_results", dnsResults).Msg("Purged historical data")
 
 	if s.config.Type == "sqlite" {
 		if _, err := s.db.ExecContext(ctx, "VACUUM"); err != nil {
@@ -54,5 +61,5 @@ func (s *service) PurgeHistoricalData(ctx context.Context, before time.Time) (sp
 		}
 	}
 
-	return speedTests, packetLoss, nil
+	return speedTests, packetLoss, dnsResults, nil
 }

--- a/internal/database/purge_integration_test.go
+++ b/internal/database/purge_integration_test.go
@@ -40,20 +40,31 @@ func TestPurgeHistoricalData(t *testing.T) {
 		recentPL := &types.PacketLossResult{MonitorID: monitor.ID, PacketsSent: 10, PacketsRecv: 10, CreatedAt: recent}
 		require.NoError(t, td.Service.SavePacketLossResult(recentPL))
 
+		// dns_results: needs a monitor (FK), one old, one recent
+		dnsMonitor := CreateTestDNSMonitor(t, td)
+		oldDNS := &types.DNSResult{MonitorID: dnsMonitor.ID, ResponseTimeMs: 12, ResponseCode: "NOERROR", Success: true, CreatedAt: old}
+		require.NoError(t, td.Service.SaveDNSResult(oldDNS))
+		recentDNS := &types.DNSResult{MonitorID: dnsMonitor.ID, ResponseTimeMs: 14, ResponseCode: "NOERROR", Success: true, CreatedAt: recent}
+		require.NoError(t, td.Service.SaveDNSResult(recentDNS))
+
 		// Purge everything older than the cutoff.
-		speedTests, packetLoss, err := td.Service.PurgeHistoricalData(ctx, cutoff)
+		speedTests, packetLoss, dnsResults, err := td.Service.PurgeHistoricalData(ctx, cutoff)
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), speedTests)
 		assert.Equal(t, int64(1), packetLoss)
+		assert.Equal(t, int64(1), dnsResults)
 
 		// Only the recent rows should survive.
 		AssertRecordExists(t, td, "speed_tests", "id", recentST.ID)
 		AssertRecordExists(t, td, "packet_loss_results", "id", recentPL.ID)
+		AssertRecordExists(t, td, "dns_results", "id", recentDNS.ID)
 
-		var stCount, plCount int
+		var stCount, plCount, dnsCount int
 		require.NoError(t, td.DB.QueryRow("SELECT COUNT(*) FROM speed_tests").Scan(&stCount))
 		require.NoError(t, td.DB.QueryRow("SELECT COUNT(*) FROM packet_loss_results").Scan(&plCount))
+		require.NoError(t, td.DB.QueryRow("SELECT COUNT(*) FROM dns_results").Scan(&dnsCount))
 		assert.Equal(t, 1, stCount)
 		assert.Equal(t, 1, plCount)
+		assert.Equal(t, 1, dnsCount)
 	})
 }

--- a/internal/dnsmonitor/probe.go
+++ b/internal/dnsmonitor/probe.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Package dnsmonitor sends DNS queries to a resolver on a schedule and records
+// the response time and the response code. It measures the resolver, not the
+// record: it does not check that an answer is correct.
+package dnsmonitor
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// queryTimeout is the time limit for one DNS query.
+const queryTimeout = 5 * time.Second
+
+// Default ports per protocol.
+const (
+	defaultPortPlain = "53"
+	defaultPortDoT   = "853"
+)
+
+// Check is the outcome of one DNS query.
+type Check struct {
+	ResponseTime time.Duration
+	ResponseCode string
+	Success      bool
+	Err          error
+}
+
+// RecordTypes are the record types a DNS monitor can ask for.
+var RecordTypes = []string{"A", "AAAA", "CNAME", "MX", "NS", "TXT"}
+
+// Probe sends one query to the monitor's resolver. A timeout, a transport
+// error, and an error response code (SERVFAIL, REFUSED, NXDOMAIN, and the like)
+// all count as a failure.
+func Probe(monitor *types.DNSMonitor) Check {
+	recordType, ok := dns.StringToType[strings.ToUpper(monitor.RecordType)]
+	if !ok {
+		return Check{Err: fmt.Errorf("unknown record type %q", monitor.RecordType)}
+	}
+
+	client := &dns.Client{Net: network(monitor.Protocol), Timeout: queryTimeout}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(monitor.Query), recordType)
+
+	// With a nil TLSConfig, DoT verifies the certificate against the host part
+	// of the address. A mismatch fails the check, which is the correct signal.
+	response, rtt, err := client.Exchange(msg, address(monitor.Host, monitor.Protocol))
+	if err != nil {
+		return Check{ResponseTime: rtt, Err: err}
+	}
+
+	code := dns.RcodeToString[response.Rcode]
+	if response.Rcode != dns.RcodeSuccess {
+		return Check{ResponseTime: rtt, ResponseCode: code, Err: fmt.Errorf("response code %s", code)}
+	}
+
+	return Check{ResponseTime: rtt, ResponseCode: code, Success: true}
+}
+
+// address adds the default port for the protocol when the host has none.
+func address(host, protocol string) string {
+	host = strings.TrimSpace(host)
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return host
+	}
+
+	port := defaultPortPlain
+	if protocol == types.DNSProtocolDoT {
+		port = defaultPortDoT
+	}
+
+	return net.JoinHostPort(host, port)
+}
+
+func network(protocol string) string {
+	switch protocol {
+	case types.DNSProtocolTCP:
+		return "tcp"
+	case types.DNSProtocolDoT:
+		return "tcp-tls"
+	default:
+		return "udp"
+	}
+}

--- a/internal/dnsmonitor/probe_test.go
+++ b/internal/dnsmonitor/probe_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dnsmonitor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// answer replies with one A record for whatever was asked.
+func answer(w dns.ResponseWriter, req *dns.Msg) {
+	msg := new(dns.Msg)
+	msg.SetReply(req)
+	rr, err := dns.NewRR(req.Question[0].Name + " 60 IN A 127.0.0.1")
+	if err == nil {
+		msg.Answer = append(msg.Answer, rr)
+	}
+	_ = w.WriteMsg(msg)
+}
+
+func rcode(code int) dns.HandlerFunc {
+	return func(w dns.ResponseWriter, req *dns.Msg) {
+		msg := new(dns.Msg)
+		msg.SetRcode(req, code)
+		_ = w.WriteMsg(msg)
+	}
+}
+
+// startUDPServer runs a DNS server on a loopback port and returns its address.
+func startUDPServer(t *testing.T, handler dns.Handler) string {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &dns.Server{PacketConn: conn, Handler: handler}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	return conn.LocalAddr().String()
+}
+
+func startTCPServer(t *testing.T, handler dns.Handler) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &dns.Server{Listener: listener, Handler: handler}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	return listener.Addr().String()
+}
+
+func monitorFor(host, protocol string) *types.DNSMonitor {
+	return &types.DNSMonitor{
+		Host:       host,
+		Protocol:   protocol,
+		Query:      "example.invalid",
+		RecordType: "A",
+	}
+}
+
+func TestProbe_Success(t *testing.T) {
+	addr := startUDPServer(t, dns.HandlerFunc(answer))
+
+	check := Probe(monitorFor(addr, types.DNSProtocolUDP))
+
+	assert.True(t, check.Success)
+	assert.Equal(t, "NOERROR", check.ResponseCode)
+	assert.NoError(t, check.Err)
+	assert.Positive(t, check.ResponseTime)
+}
+
+func TestProbe_OverTCP(t *testing.T) {
+	addr := startTCPServer(t, dns.HandlerFunc(answer))
+
+	check := Probe(monitorFor(addr, types.DNSProtocolTCP))
+
+	assert.True(t, check.Success)
+	assert.Equal(t, "NOERROR", check.ResponseCode)
+}
+
+func TestProbe_ErrorResponseCodesFail(t *testing.T) {
+	for name, code := range map[string]int{
+		"SERVFAIL": dns.RcodeServerFailure,
+		"REFUSED":  dns.RcodeRefused,
+		"NXDOMAIN": dns.RcodeNameError,
+	} {
+		t.Run(name, func(t *testing.T) {
+			addr := startUDPServer(t, rcode(code))
+
+			check := Probe(monitorFor(addr, types.DNSProtocolUDP))
+
+			assert.False(t, check.Success)
+			assert.Equal(t, name, check.ResponseCode)
+			assert.Error(t, check.Err)
+		})
+	}
+}
+
+func TestProbe_TimeoutFails(t *testing.T) {
+	// a server that never answers, so the query runs into queryTimeout
+	addr := startUDPServer(t, dns.HandlerFunc(func(dns.ResponseWriter, *dns.Msg) {}))
+
+	check := Probe(monitorFor(addr, types.DNSProtocolUDP))
+
+	assert.False(t, check.Success)
+	assert.Empty(t, check.ResponseCode)
+	require.Error(t, check.Err)
+	assert.Contains(t, check.Err.Error(), "timeout")
+}
+
+func TestProbe_UnknownRecordType(t *testing.T) {
+	monitor := monitorFor("127.0.0.1:5353", types.DNSProtocolUDP)
+	monitor.RecordType = "BOGUS"
+
+	check := Probe(monitor)
+
+	assert.False(t, check.Success)
+	require.Error(t, check.Err)
+	assert.Contains(t, check.Err.Error(), "unknown record type")
+}
+
+func TestAddress(t *testing.T) {
+	tests := []struct {
+		host     string
+		protocol string
+		want     string
+	}{
+		{"1.1.1.1", types.DNSProtocolUDP, "1.1.1.1:53"},
+		{"1.1.1.1", types.DNSProtocolTCP, "1.1.1.1:53"},
+		{"one.one.one.one", types.DNSProtocolDoT, "one.one.one.one:853"},
+		{"1.1.1.1:5353", types.DNSProtocolUDP, "1.1.1.1:5353"},
+		{" 1.1.1.1 ", types.DNSProtocolUDP, "1.1.1.1:53"},
+		{"2606:4700:4700::1111", types.DNSProtocolUDP, "[2606:4700:4700::1111]:53"},
+		{"[2606:4700:4700::1111]:5353", types.DNSProtocolUDP, "[2606:4700:4700::1111]:5353"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.host+"/"+test.protocol, func(t *testing.T) {
+			assert.Equal(t, test.want, address(test.host, test.protocol))
+		})
+	}
+}

--- a/internal/dnsmonitor/service.go
+++ b/internal/dnsmonitor/service.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dnsmonitor
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/notifications"
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// Monitor states. A monitor goes to StateDown on a failed check and to
+// StateRecovered on the first success after that.
+const (
+	StateOK        = "ok"
+	StateDown      = "down"
+	StateRecovered = "recovered"
+)
+
+// Service runs DNS monitor checks and records what they find.
+type Service struct {
+	db        database.Service
+	notifier  *notifications.Notifier
+	mu        sync.RWMutex
+	broadcast func(types.DNSUpdate)
+}
+
+func NewService(db database.Service, notifier *notifications.Notifier) *Service {
+	return &Service{db: db, notifier: notifier}
+}
+
+// SetBroadcast sets the broadcast function for the service
+func (s *Service) SetBroadcast(broadcast func(types.DNSUpdate)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broadcast = broadcast
+}
+
+func (s *Service) send(update types.DNSUpdate) {
+	s.mu.RLock()
+	broadcast := s.broadcast
+	s.mu.RUnlock()
+
+	if broadcast != nil {
+		broadcast(update)
+	}
+}
+
+// RunCheck sends one query for the monitor, saves the result, moves the monitor
+// between states, and sends a notification on a state change.
+func (s *Service) RunCheck(monitor *types.DNSMonitor) {
+	s.send(types.DNSUpdate{
+		Type:      "dns",
+		MonitorID: monitor.ID,
+		Host:      monitor.Host,
+		IsRunning: true,
+		Enabled:   monitor.Enabled,
+	})
+
+	check := Probe(monitor)
+
+	result := &types.DNSResult{
+		MonitorID:      monitor.ID,
+		ResponseTimeMs: float64(check.ResponseTime.Microseconds()) / 1000,
+		ResponseCode:   check.ResponseCode,
+		Success:        check.Success,
+		CreatedAt:      time.Now(),
+	}
+	if check.Err != nil {
+		errText := check.Err.Error()
+		result.Error = &errText
+	}
+
+	log.Debug().
+		Int64("monitorID", monitor.ID).
+		Str("host", monitor.Host).
+		Str("protocol", monitor.Protocol).
+		Float64("responseTimeMs", result.ResponseTimeMs).
+		Str("responseCode", result.ResponseCode).
+		Bool("success", result.Success).
+		Msg("DNS check completed")
+
+	if err := s.db.SaveDNSResult(result); err != nil {
+		log.Error().Err(err).Int64("monitorID", monitor.ID).Msg("Failed to save dns result")
+	}
+
+	state := s.applyState(monitor, check)
+
+	update := types.DNSUpdate{
+		Type:           "dns",
+		MonitorID:      monitor.ID,
+		Host:           monitor.Host,
+		Enabled:        monitor.Enabled,
+		Success:        result.Success,
+		ResponseTimeMs: result.ResponseTimeMs,
+		ResponseCode:   result.ResponseCode,
+		State:          state,
+	}
+	if result.Error != nil {
+		update.Error = *result.Error
+	}
+	s.send(update)
+}
+
+// applyState moves the monitor to its new state and notifies on a change. It
+// returns the state the monitor is in after the check.
+func (s *Service) applyState(monitor *types.DNSMonitor, check Check) string {
+	previous := monitor.LastState
+
+	state := StateOK
+	switch {
+	case !check.Success:
+		state = StateDown
+	case previous == StateDown:
+		state = StateRecovered
+	}
+
+	if state == previous {
+		return state
+	}
+
+	if err := s.db.UpdateDNSMonitorState(monitor.ID, state); err != nil {
+		log.Error().Err(err).Int64("monitorID", monitor.ID).Str("state", state).Msg("Failed to update dns monitor state")
+	}
+	monitor.LastState = state
+
+	if s.notifier == nil || (state != StateDown && state != StateRecovered) {
+		return state
+	}
+
+	name := monitor.Name
+	if name == "" {
+		name = monitor.Host
+	}
+
+	detail := fmt.Sprintf("Response time: %.0f ms", float64(check.ResponseTime.Microseconds())/1000)
+	if check.Err != nil {
+		detail = check.Err.Error()
+	}
+
+	if err := s.notifier.SendDNSNotification(name, monitor.Host, detail, state == StateDown); err != nil {
+		log.Error().Err(err).Int64("monitorID", monitor.ID).Str("state", state).Msg("Failed to send dns notification")
+	}
+
+	return state
+}
+
+// GetMonitorStatus returns the last known status of a monitor.
+func (s *Service) GetMonitorStatus(monitorID int64) (*types.DNSUpdate, error) {
+	monitor, err := s.db.GetDNSMonitor(monitorID)
+	if err != nil {
+		return nil, err
+	}
+
+	update := &types.DNSUpdate{
+		Type:      "dns",
+		MonitorID: monitor.ID,
+		Host:      monitor.Host,
+		Enabled:   monitor.Enabled,
+		State:     monitor.LastState,
+	}
+
+	result, err := s.db.GetLatestDNSResult(monitorID)
+	if err == database.ErrNotFound {
+		return update, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	update.Success = result.Success
+	update.ResponseTimeMs = result.ResponseTimeMs
+	update.ResponseCode = result.ResponseCode
+	if result.Error != nil {
+		update.Error = *result.Error
+	}
+
+	return update, nil
+}

--- a/internal/dnsmonitor/service_test.go
+++ b/internal/dnsmonitor/service_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dnsmonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/config"
+	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// testDB is one SQLite database with the schema applied. The database package
+// keeps a single instance per process, so every test here shares it and works
+// on its own monitor rows.
+var testDB database.Service
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "netronome-dnsmonitor")
+	if err != nil {
+		panic(err)
+	}
+
+	testDB = database.New(config.DatabaseConfig{
+		Type: config.SQLite,
+		Path: filepath.Join(dir, "dnsmonitor_test.db"),
+	})
+	if err := testDB.InitializeTables(context.Background()); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+
+	_ = testDB.Close()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// startFlakyResolver answers while healthy is true and returns SERVFAIL
+// otherwise, so a test can make the same monitor pass and fail.
+func startFlakyResolver(t *testing.T, healthy *atomic.Bool) string {
+	return startUDPServer(t, dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		if !healthy.Load() {
+			rcode(dns.RcodeServerFailure)(w, req)
+			return
+		}
+		answer(w, req)
+	}))
+}
+
+func TestRunCheck_RecordsResultAndStates(t *testing.T) {
+	db := testDB
+
+	var healthy atomic.Bool
+	healthy.Store(true)
+	addr := startFlakyResolver(t, &healthy)
+
+	monitor, err := db.CreateDNSMonitor(&types.DNSMonitor{
+		Name:       "Local resolver",
+		Host:       addr,
+		Protocol:   types.DNSProtocolUDP,
+		Query:      "example.invalid",
+		RecordType: "A",
+		Interval:   "60s",
+		Enabled:    true,
+	})
+	require.NoError(t, err)
+
+	service := NewService(db, nil)
+
+	// a healthy resolver records a successful check and the normal state
+	service.RunCheck(monitor)
+
+	result, err := db.GetLatestDNSResult(monitor.ID)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "NOERROR", result.ResponseCode)
+	assert.Positive(t, result.ResponseTimeMs)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, StateOK, reloadState(t, db, monitor.ID))
+
+	// a failing resolver moves the monitor to down and keeps the reason
+	healthy.Store(false)
+	service.RunCheck(monitor)
+
+	result, err = db.GetLatestDNSResult(monitor.ID)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, "SERVFAIL", result.ResponseCode)
+	require.NotNil(t, result.Error)
+	assert.Contains(t, *result.Error, "SERVFAIL")
+	assert.Equal(t, StateDown, reloadState(t, db, monitor.ID))
+
+	// the next success recovers it, through a fresh service and a monitor read
+	// back from the database, as a restart would do
+	healthy.Store(true)
+	reloaded, err := db.GetDNSMonitor(monitor.ID)
+	require.NoError(t, err)
+	NewService(db, nil).RunCheck(reloaded)
+
+	assert.Equal(t, StateRecovered, reloadState(t, db, monitor.ID))
+
+	history, err := db.GetDNSResults(monitor.ID, 1, 25)
+	require.NoError(t, err)
+	assert.Equal(t, 3, history.Total)
+}
+
+func TestRunCheck_BroadcastsStartAndResult(t *testing.T) {
+	db := testDB
+	addr := startUDPServer(t, dns.HandlerFunc(answer))
+
+	monitor, err := db.CreateDNSMonitor(&types.DNSMonitor{
+		Host:       addr,
+		Protocol:   types.DNSProtocolUDP,
+		Query:      "example.invalid",
+		RecordType: "A",
+		Interval:   "60s",
+		Enabled:    true,
+	})
+	require.NoError(t, err)
+
+	var updates []types.DNSUpdate
+	service := NewService(db, nil)
+	service.SetBroadcast(func(update types.DNSUpdate) { updates = append(updates, update) })
+
+	service.RunCheck(monitor)
+
+	require.Len(t, updates, 2)
+	assert.True(t, updates[0].IsRunning)
+	assert.False(t, updates[1].IsRunning)
+	assert.True(t, updates[1].Success)
+	assert.Equal(t, "NOERROR", updates[1].ResponseCode)
+	assert.Equal(t, StateOK, updates[1].State)
+}
+
+func TestGetMonitorStatus_WithoutResults(t *testing.T) {
+	db := testDB
+
+	monitor, err := db.CreateDNSMonitor(&types.DNSMonitor{
+		Host:       "127.0.0.1:5353",
+		Protocol:   types.DNSProtocolUDP,
+		Query:      "example.invalid",
+		RecordType: "A",
+		Interval:   "60s",
+		Enabled:    false,
+	})
+	require.NoError(t, err)
+
+	status, err := NewService(db, nil).GetMonitorStatus(monitor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, monitor.ID, status.MonitorID)
+	assert.False(t, status.Enabled)
+	assert.False(t, status.Success)
+	assert.Zero(t, status.ResponseTimeMs)
+}
+
+func reloadState(t *testing.T, db database.Service, monitorID int64) string {
+	t.Helper()
+
+	monitor, err := db.GetDNSMonitor(monitorID)
+	require.NoError(t, err)
+	return monitor.LastState
+}

--- a/internal/handlers/dns.go
+++ b/internal/handlers/dns.go
@@ -127,12 +127,14 @@ func (h *DNSHandler) CreateMonitor(c *gin.Context) {
 		return
 	}
 
-	if nextRun := h.scheduler.CalculateNextRun(monitor.Interval, time.Now()); !nextRun.IsZero() {
-		monitor.NextRun = &nextRun
-	} else {
+	// a new monitor runs on the next scheduler tick; the interval only has to
+	// parse
+	now := time.Now().UTC()
+	if h.scheduler.CalculateNextRun(monitor.Interval, now).IsZero() {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid interval"})
 		return
 	}
+	monitor.NextRun = &now
 
 	created, err := h.db.CreateDNSMonitor(&monitor)
 	if err != nil {

--- a/internal/handlers/dns.go
+++ b/internal/handlers/dns.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/dnsmonitor"
+	"github.com/autobrr/netronome/internal/scheduler"
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// DNSHandler handles DNS monitoring endpoints
+type DNSHandler struct {
+	db        database.Service
+	service   *dnsmonitor.Service
+	scheduler scheduler.Service
+}
+
+func NewDNSHandler(db database.Service, service *dnsmonitor.Service, scheduler scheduler.Service) *DNSHandler {
+	return &DNSHandler{db: db, service: service, scheduler: scheduler}
+}
+
+// dnsMonitorRequest is the monitor as the API takes it. Enabled is a pointer so
+// that a body without the field keeps the default (a new monitor runs) instead
+// of the zero value (a monitor that never runs).
+type dnsMonitorRequest struct {
+	Host       string `json:"host"`
+	Name       string `json:"name"`
+	Protocol   string `json:"protocol"`
+	Query      string `json:"query"`
+	RecordType string `json:"recordType"`
+	Interval   string `json:"interval"`
+	Enabled    *bool  `json:"enabled"`
+}
+
+// monitor applies the request to a monitor, with enabled as the fallback for a
+// request that does not carry the field.
+func (r dnsMonitorRequest) monitor(enabled bool) types.DNSMonitor {
+	if r.Enabled != nil {
+		enabled = *r.Enabled
+	}
+
+	return types.DNSMonitor{
+		Host:       r.Host,
+		Name:       r.Name,
+		Protocol:   r.Protocol,
+		Query:      r.Query,
+		RecordType: r.RecordType,
+		Interval:   r.Interval,
+		Enabled:    enabled,
+	}
+}
+
+// normalizeDNSMonitor fills in the defaults and reports the first invalid
+// field. Its error text goes straight to the caller.
+func normalizeDNSMonitor(monitor *types.DNSMonitor) error {
+	monitor.Host = strings.TrimSpace(monitor.Host)
+	if monitor.Host == "" {
+		return errors.New("Host is required")
+	}
+
+	monitor.Query = strings.TrimSpace(monitor.Query)
+	if monitor.Query == "" {
+		monitor.Query = "google.com"
+	}
+
+	monitor.Protocol = strings.ToLower(strings.TrimSpace(monitor.Protocol))
+	if monitor.Protocol == "" {
+		monitor.Protocol = types.DNSProtocolUDP
+	}
+	switch monitor.Protocol {
+	case types.DNSProtocolUDP, types.DNSProtocolTCP, types.DNSProtocolDoT:
+	default:
+		return errors.New("Protocol must be one of: udp, tcp, dot")
+	}
+
+	monitor.RecordType = strings.ToUpper(strings.TrimSpace(monitor.RecordType))
+	if monitor.RecordType == "" {
+		monitor.RecordType = "A"
+	}
+	if !slices.Contains(dnsmonitor.RecordTypes, monitor.RecordType) {
+		return errors.New("Record type must be one of: " + strings.Join(dnsmonitor.RecordTypes, ", "))
+	}
+
+	if strings.TrimSpace(monitor.Interval) == "" {
+		monitor.Interval = "60s"
+	}
+
+	return nil
+}
+
+// GetMonitors returns all DNS monitors
+func (h *DNSHandler) GetMonitors(c *gin.Context) {
+	monitors, err := h.db.GetDNSMonitors()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get dns monitors")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitors"})
+		return
+	}
+
+	c.JSON(http.StatusOK, monitors)
+}
+
+// CreateMonitor creates a new DNS monitor
+func (h *DNSHandler) CreateMonitor(c *gin.Context) {
+	var request dnsMonitorRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	// a new monitor runs unless the caller says otherwise
+	monitor := request.monitor(true)
+	if err := normalizeDNSMonitor(&monitor); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if nextRun := h.scheduler.CalculateNextRun(monitor.Interval, time.Now()); !nextRun.IsZero() {
+		monitor.NextRun = &nextRun
+	} else {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid interval"})
+		return
+	}
+
+	created, err := h.db.CreateDNSMonitor(&monitor)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create dns monitor")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create monitor"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, created)
+}
+
+// UpdateMonitor updates an existing DNS monitor
+func (h *DNSHandler) UpdateMonitor(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid monitor ID"})
+		return
+	}
+
+	var request dnsMonitorRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	// keep the scheduling fields the user does not send
+	monitor, err := h.db.GetDNSMonitor(id)
+	if err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Monitor not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor"})
+		return
+	}
+
+	updateData := request.monitor(monitor.Enabled)
+	if err := normalizeDNSMonitor(&updateData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	monitor.Host = updateData.Host
+	monitor.Name = updateData.Name
+	monitor.Protocol = updateData.Protocol
+	monitor.Query = updateData.Query
+	monitor.RecordType = updateData.RecordType
+	monitor.Enabled = updateData.Enabled
+
+	if monitor.Interval != updateData.Interval {
+		monitor.Interval = updateData.Interval
+		nextRun := h.scheduler.CalculateNextRun(monitor.Interval, time.Now())
+		if nextRun.IsZero() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid interval"})
+			return
+		}
+		monitor.NextRun = &nextRun
+	}
+
+	if err := h.db.UpdateDNSMonitor(monitor); err != nil {
+		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to update dns monitor")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update monitor"})
+		return
+	}
+
+	c.JSON(http.StatusOK, monitor)
+}
+
+// DeleteMonitor deletes a DNS monitor and its results
+func (h *DNSHandler) DeleteMonitor(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid monitor ID"})
+		return
+	}
+
+	if err := h.db.DeleteDNSMonitor(id); err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Monitor not found"})
+			return
+		}
+		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to delete dns monitor")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete monitor"})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// GetMonitorStatus returns the last known status of a monitor
+func (h *DNSHandler) GetMonitorStatus(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid monitor ID"})
+		return
+	}
+
+	status, err := h.service.GetMonitorStatus(id)
+	if err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Monitor not found"})
+			return
+		}
+		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to get dns monitor status")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor status"})
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// GetMonitorHistory returns paginated results for a monitor
+func (h *DNSHandler) GetMonitorHistory(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid monitor ID"})
+		return
+	}
+
+	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if err != nil || page <= 0 {
+		page = 1
+	}
+
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "25"))
+	if err != nil || limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	// an unknown monitor is a 404 here as it is on the status route, not an
+	// empty page
+	if _, err := h.db.GetDNSMonitor(id); err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Monitor not found"})
+			return
+		}
+		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to get dns monitor")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor history"})
+		return
+	}
+
+	results, err := h.db.GetDNSResults(id, page, limit)
+	if err != nil {
+		log.Error().Err(err).Int64("monitorID", id).Msg("Failed to get dns results")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get monitor history"})
+		return
+	}
+
+	c.JSON(http.StatusOK, results)
+}

--- a/internal/handlers/dns_test.go
+++ b/internal/handlers/dns_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+func TestNormalizeDNSMonitor(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   types.DNSMonitor
+		want    types.DNSMonitor
+		wantErr string
+	}{
+		{
+			name:  "fills in the defaults",
+			input: types.DNSMonitor{Host: "1.1.1.1"},
+			want:  types.DNSMonitor{Host: "1.1.1.1", Protocol: "udp", Query: "google.com", RecordType: "A", Interval: "60s"},
+		},
+		{
+			name:  "trims the host and keeps the given values",
+			input: types.DNSMonitor{Host: "  dns.example.invalid:853 ", Protocol: "DoT", Query: " home.arpa ", RecordType: "aaaa", Interval: "5m"},
+			want:  types.DNSMonitor{Host: "dns.example.invalid:853", Protocol: "dot", Query: "home.arpa", RecordType: "AAAA", Interval: "5m"},
+		},
+		{
+			name:    "rejects an empty host",
+			input:   types.DNSMonitor{Host: "   "},
+			wantErr: "Host is required",
+		},
+		{
+			name:    "rejects an unknown protocol",
+			input:   types.DNSMonitor{Host: "1.1.1.1", Protocol: "doh"},
+			wantErr: "Protocol must be one of: udp, tcp, dot",
+		},
+		{
+			name:    "rejects an unknown record type",
+			input:   types.DNSMonitor{Host: "1.1.1.1", RecordType: "SOA"},
+			wantErr: "Record type must be one of: A, AAAA, CNAME, MX, NS, TXT",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			monitor := test.input
+			err := normalizeDNSMonitor(&monitor)
+
+			if test.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, test.wantErr, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, monitor)
+		})
+	}
+}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -139,6 +139,8 @@ func notificationTitle(category string) string {
 		return "Netronome"
 	case database.NotificationCategoryPacketLoss:
 		return "Netronome: Packet Loss"
+	case database.NotificationCategoryDNS:
+		return "Netronome: DNS"
 	default:
 		return "Netronome: " + strings.ToUpper(category[:1]) + category[1:]
 	}
@@ -319,6 +321,17 @@ func (n *Notifier) SendPacketLossNotification(monitorName string, host string, p
 		message = fmt.Sprintf("[!] High Packet Loss - **%s** | Host: **%s** | Loss: **%.1f%%**", monitorName, host, packetLoss)
 	}
 	return n.SendNotification(database.NotificationCategoryPacketLoss, database.NotificationEventPacketLossHigh, message, &packetLoss)
+}
+
+// SendDNSNotification sends a DNS monitor down or recovered notification
+func (n *Notifier) SendDNSNotification(monitorName string, host string, detail string, isDown bool) error {
+	if isDown {
+		message := fmt.Sprintf("[DOWN] DNS Monitor Down - **%s** | Resolver: **%s** | %s", monitorName, host, detail)
+		return n.SendNotification(database.NotificationCategoryDNS, database.NotificationEventDNSDown, message, nil)
+	}
+
+	message := fmt.Sprintf("[OK] DNS Monitor Recovered - **%s** | Resolver: **%s** | %s", monitorName, host, detail)
+	return n.SendNotification(database.NotificationCategoryDNS, database.NotificationEventDNSRecovered, message, nil)
 }
 
 // SendAgentNotification sends an agent-related notification

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/dnsmonitor"
 	"github.com/autobrr/netronome/internal/notifications"
 	"github.com/autobrr/netronome/internal/speedtest"
 	"github.com/autobrr/netronome/internal/types"
@@ -31,6 +32,7 @@ type service struct {
 	db         database.Service
 	speedtest  speedtest.Service
 	packetLoss *speedtest.PacketLossService
+	dns        *dnsmonitor.Service
 	notifier   *notifications.Notifier
 	ticker     *time.Ticker
 	done       chan bool
@@ -38,11 +40,12 @@ type service struct {
 	running    bool
 }
 
-func New(db database.Service, speedtest speedtest.Service, packetLoss *speedtest.PacketLossService, notifier *notifications.Notifier) Service {
+func New(db database.Service, speedtest speedtest.Service, packetLoss *speedtest.PacketLossService, dns *dnsmonitor.Service, notifier *notifications.Notifier) Service {
 	return &service{
 		db:         db,
 		speedtest:  speedtest,
 		packetLoss: packetLoss,
+		dns:        dns,
 		notifier:   notifier,
 		done:       make(chan bool),
 	}
@@ -62,6 +65,7 @@ func (s *service) Start(ctx context.Context) {
 	// Initialize schedules before starting
 	s.initializeSchedules(ctx)
 	s.initializePacketLossMonitors(ctx)
+	s.initializeDNSMonitors()
 
 	go func() {
 		for {
@@ -74,6 +78,7 @@ func (s *service) Start(ctx context.Context) {
 			case <-s.ticker.C:
 				s.checkAndRunScheduledTests(ctx)
 				s.checkAndRunPacketLossMonitors(ctx)
+				s.checkAndRunDNSMonitors()
 			}
 		}
 	}()
@@ -602,6 +607,87 @@ func (s *service) UpdateMonitorSchedule(monitorID int64, interval string) error 
 		Msg("Updating monitor schedule after test completion")
 
 	return s.db.UpdatePacketLossMonitor(monitor)
+}
+
+// initializeDNSMonitors gives every enabled DNS monitor a next run time on
+// startup. Missed runs are not executed, as with the other schedules.
+func (s *service) initializeDNSMonitors() {
+	if s.dns == nil {
+		return
+	}
+
+	monitors, err := s.db.GetDNSMonitors()
+	if err != nil {
+		log.Error().Err(err).Msg("Error fetching dns monitors during initialization")
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, monitor := range monitors {
+		if !monitor.Enabled || (monitor.NextRun != nil && monitor.NextRun.After(now)) {
+			continue
+		}
+
+		nextRun := s.calculateNextRun(monitor.Interval, now, true)
+		if nextRun.IsZero() {
+			log.Error().
+				Int64("monitor_id", monitor.ID).
+				Str("interval", monitor.Interval).
+				Msg("Could not calculate next run time for dns monitor")
+			continue
+		}
+
+		monitor.NextRun = &nextRun
+		if err := s.db.UpdateDNSMonitor(monitor); err != nil {
+			log.Error().Err(err).Int64("monitor_id", monitor.ID).Msg("Error updating dns monitor during initialization")
+		}
+	}
+}
+
+// checkAndRunDNSMonitors runs every enabled DNS monitor that is due
+func (s *service) checkAndRunDNSMonitors() {
+	if s.dns == nil {
+		return
+	}
+
+	monitors, err := s.db.GetDNSMonitors()
+	if err != nil {
+		log.Error().Err(err).Msg("Error fetching dns monitors")
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, monitor := range monitors {
+		if !monitor.Enabled || monitor.NextRun == nil || monitor.NextRun.UTC().After(now) {
+			continue
+		}
+
+		scheduledStart := monitor.NextRun.UTC()
+		go func(monitor *types.DNSMonitor, scheduledStart time.Time) {
+			s.dns.RunCheck(monitor)
+
+			// keep the interval steady by counting from the scheduled start,
+			// unless the check ran past the next slot
+			nextRun := s.calculateNextRun(monitor.Interval, scheduledStart, true)
+			if nextRun.IsZero() {
+				log.Error().
+					Int64("monitor_id", monitor.ID).
+					Str("interval", monitor.Interval).
+					Msg("Error calculating next run time for dns monitor")
+				return
+			}
+			if completed := time.Now().UTC(); nextRun.Before(completed) {
+				nextRun = s.calculateNextRun(monitor.Interval, completed, true)
+			}
+
+			monitor.LastRun = &scheduledStart
+			monitor.NextRun = &nextRun
+
+			if err := s.db.UpdateDNSMonitor(monitor); err != nil {
+				log.Error().Err(err).Int64("monitor_id", monitor.ID).Msg("Error updating dns monitor schedule")
+			}
+		}(monitor, scheduledStart)
+	}
 }
 
 // CalculateNextRun is a public wrapper for calculateNextRun

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -637,8 +637,7 @@ func (s *service) initializeDNSMonitors() {
 			continue
 		}
 
-		monitor.NextRun = &nextRun
-		if err := s.db.UpdateDNSMonitor(monitor); err != nil {
+		if err := s.db.UpdateDNSMonitorSchedule(monitor.ID, monitor.LastRun, nextRun); err != nil {
 			log.Error().Err(err).Int64("monitor_id", monitor.ID).Msg("Error updating dns monitor during initialization")
 		}
 	}
@@ -680,10 +679,9 @@ func (s *service) checkAndRunDNSMonitors() {
 				nextRun = s.calculateNextRun(monitor.Interval, completed, true)
 			}
 
-			monitor.LastRun = &scheduledStart
-			monitor.NextRun = &nextRun
-
-			if err := s.db.UpdateDNSMonitor(monitor); err != nil {
+			// only the run times, so a user edit made while the check ran
+			// survives
+			if err := s.db.UpdateDNSMonitorSchedule(monitor.ID, &scheduledStart, nextRun); err != nil {
 				log.Error().Err(err).Int64("monitor_id", monitor.ID).Msg("Error updating dns monitor schedule")
 			}
 		}(monitor, scheduledStart)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/autobrr/netronome/internal/broadcaster"
 	"github.com/autobrr/netronome/internal/config"
 	"github.com/autobrr/netronome/internal/database"
+	"github.com/autobrr/netronome/internal/dnsmonitor"
 	"github.com/autobrr/netronome/internal/handlers"
 	"github.com/autobrr/netronome/internal/monitor"
 	"github.com/autobrr/netronome/internal/notifications"
@@ -34,6 +35,7 @@ type Server struct {
 	Router               *gin.Engine
 	speedtest            speedtest.Service
 	packetLossService    *speedtest.PacketLossService
+	dnsService           *dnsmonitor.Service
 	monitorService       *monitor.Service
 	db                   database.Service
 	scheduler            scheduler.Service
@@ -43,6 +45,7 @@ type Server struct {
 	lastUpdate           *types.SpeedUpdate
 	lastTracerouteUpdate *types.TracerouteUpdate
 	lastPacketLossUpdate *types.PacketLossUpdate
+	lastDNSUpdate        *types.DNSUpdate
 	lastMonitorUpdate    *types.MonitorUpdate
 	config               *config.Config
 	licenseService       *license.Service
@@ -53,7 +56,7 @@ func (s *Server) SetUpdateChecker(checker *update.Checker) {
 	s.updateChecker = checker
 }
 
-func NewServer(speedtest speedtest.Service, db database.Service, scheduler scheduler.Service, cfg *config.Config, packetLossService *speedtest.PacketLossService, monitorService *monitor.Service, notifier *notifications.Notifier, licenseService *license.Service) *Server {
+func NewServer(speedtest speedtest.Service, db database.Service, scheduler scheduler.Service, cfg *config.Config, packetLossService *speedtest.PacketLossService, dnsService *dnsmonitor.Service, monitorService *monitor.Service, notifier *notifications.Notifier, licenseService *license.Service) *Server {
 	// Set Gin mode from config
 	if cfg.Server.GinMode != "" {
 		gin.SetMode(cfg.Server.GinMode)
@@ -97,6 +100,7 @@ func NewServer(speedtest speedtest.Service, db database.Service, scheduler sched
 		Router:            router,
 		speedtest:         speedtest,
 		packetLossService: packetLossService,
+		dnsService:        dnsService,
 		monitorService:    monitorService,
 		db:                db,
 		scheduler:         scheduler,
@@ -151,6 +155,21 @@ func (s *Server) BroadcastPacketLossUpdate(update types.PacketLossUpdate) {
 		Bool("isComplete", update.IsComplete).
 		Float64("packetLoss", update.PacketLoss).
 		Msg("Broadcasting packet loss update")
+}
+
+func (s *Server) BroadcastDNSUpdate(update types.DNSUpdate) {
+	s.mu.Lock()
+	s.lastDNSUpdate = &update
+	s.mu.Unlock()
+
+	log.Debug().
+		Int64("monitorID", update.MonitorID).
+		Str("host", update.Host).
+		Bool("isRunning", update.IsRunning).
+		Bool("success", update.Success).
+		Str("responseCode", update.ResponseCode).
+		Float64("responseTimeMs", update.ResponseTimeMs).
+		Msg("Broadcasting dns update")
 }
 
 func (s *Server) BroadcastMonitorUpdate(update types.MonitorUpdate) {
@@ -284,6 +303,17 @@ func (s *Server) RegisterRoutes() {
 				protected.GET("/packetloss/monitors/:id/history/:resultId", packetLossHandler.GetMonitorHistoryDetail)
 				protected.POST("/packetloss/monitors/:id/start", packetLossHandler.StartMonitor)
 				protected.POST("/packetloss/monitors/:id/stop", packetLossHandler.StopMonitor)
+			}
+
+			// DNS monitoring routes
+			if s.dnsService != nil {
+				dnsHandler := handlers.NewDNSHandler(s.db, s.dnsService, s.scheduler)
+				protected.GET("/dns/monitors", dnsHandler.GetMonitors)
+				protected.POST("/dns/monitors", dnsHandler.CreateMonitor)
+				protected.PUT("/dns/monitors/:id", dnsHandler.UpdateMonitor)
+				protected.DELETE("/dns/monitors/:id", dnsHandler.DeleteMonitor)
+				protected.GET("/dns/monitors/:id/status", dnsHandler.GetMonitorStatus)
+				protected.GET("/dns/monitors/:id/history", dnsHandler.GetMonitorHistory)
 			}
 
 			// Vnstat monitoring routes

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -91,6 +91,7 @@ type purgeHistoryRequest struct {
 type purgeHistoryResponse struct {
 	SpeedTests int64 `json:"speedTests"`
 	PacketLoss int64 `json:"packetLoss"`
+	DNS        int64 `json:"dns"`
 }
 
 func (s *Server) handlePurgeHistory(c *gin.Context) {
@@ -109,14 +110,14 @@ func (s *Server) handlePurgeHistory(c *gin.Context) {
 	// missing or null) is rejected above so a malformed body can't purge all.
 	before := time.Now().AddDate(0, 0, -*req.OlderThanDays)
 
-	speedTests, packetLoss, err := s.db.PurgeHistoricalData(c.Request.Context(), before)
+	speedTests, packetLoss, dnsResults, err := s.db.PurgeHistoricalData(c.Request.Context(), before)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to purge historical data")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to purge historical data"})
 		return
 	}
 
-	c.JSON(http.StatusOK, purgeHistoryResponse{SpeedTests: speedTests, PacketLoss: packetLoss})
+	c.JSON(http.StatusOK, purgeHistoryResponse{SpeedTests: speedTests, PacketLoss: packetLoss, DNS: dnsResults})
 }
 
 func isAllowedDashboardRecentRows(rows int) bool {

--- a/internal/server/update_test.go
+++ b/internal/server/update_test.go
@@ -32,7 +32,7 @@ func TestLatestVersionRouteUsesBaseURLAndReturnsCachedRelease(t *testing.T) {
 	cfg := config.New()
 	cfg.Server.BaseURL = "/netronome"
 	cfg.Auth.Whitelist = []string{"127.0.0.1/32"}
-	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil)
+	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil, nil)
 	server.SetUpdateChecker(checker)
 	server.RegisterRoutes()
 
@@ -49,7 +49,7 @@ func TestLatestVersionRouteReturnsNoContentWithoutCachedRelease(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := config.New()
 	cfg.Auth.Whitelist = []string{"127.0.0.1/32"}
-	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil)
+	server := NewServer(nil, nil, nil, cfg, nil, nil, nil, nil, nil)
 	server.SetUpdateChecker(update.New(false, "1.2.3", nil))
 	server.RegisterRoutes()
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -190,6 +190,65 @@ type PaginatedPacketLossResults struct {
 	Limit int                       `json:"limit"`
 }
 
+// DNS protocols a DNS monitor can use.
+const (
+	DNSProtocolUDP = "udp"
+	DNSProtocolTCP = "tcp"
+	DNSProtocolDoT = "dot"
+)
+
+// DNSMonitor is a resolver, an interval, a query, and a protocol. The server
+// sends the query to the resolver and records the response time and the
+// response code. It measures the resolver, not the record.
+type DNSMonitor struct {
+	ID              int64      `db:"id" json:"id"`
+	Host            string     `db:"host" json:"host"`
+	Name            string     `db:"name" json:"name"`
+	Protocol        string     `db:"protocol" json:"protocol"`
+	Query           string     `db:"query" json:"query"`
+	RecordType      string     `db:"record_type" json:"recordType"`
+	Interval        string     `db:"interval" json:"interval"`
+	Enabled         bool       `db:"enabled" json:"enabled"`
+	LastRun         *time.Time `db:"last_run" json:"lastRun"`
+	NextRun         *time.Time `db:"next_run" json:"nextRun"`
+	LastState       string     `db:"last_state" json:"lastState"`
+	LastStateChange *time.Time `db:"last_state_change" json:"lastStateChange"`
+	CreatedAt       time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt       time.Time  `db:"updated_at" json:"updatedAt"`
+}
+
+// DNSResult is one recorded DNS check.
+type DNSResult struct {
+	ID             int64     `db:"id" json:"id"`
+	MonitorID      int64     `db:"monitor_id" json:"monitorId"`
+	ResponseTimeMs float64   `db:"response_time_ms" json:"responseTimeMs"`
+	ResponseCode   string    `db:"response_code" json:"responseCode"`
+	Success        bool      `db:"success" json:"success"`
+	Error          *string   `db:"error" json:"error,omitempty"`
+	CreatedAt      time.Time `db:"created_at" json:"createdAt"`
+}
+
+type PaginatedDNSResults struct {
+	Data  []DNSResult `json:"data"`
+	Total int         `json:"total"`
+	Page  int         `json:"page"`
+	Limit int         `json:"limit"`
+}
+
+// DNSUpdate is the live status of a DNS monitor.
+type DNSUpdate struct {
+	Type           string  `json:"type"`
+	MonitorID      int64   `json:"monitorId"`
+	Host           string  `json:"host"`
+	IsRunning      bool    `json:"isRunning"`
+	Enabled        bool    `json:"enabled"`
+	Success        bool    `json:"success"`
+	ResponseTimeMs float64 `json:"responseTimeMs,omitempty"`
+	ResponseCode   string  `json:"responseCode,omitempty"`
+	State          string  `json:"state,omitempty"`
+	Error          string  `json:"error,omitempty"`
+}
+
 // MonitorAgent represents a monitoring agent configuration
 type MonitorAgent struct {
 	ID                int64      `db:"id" json:"id"`


### PR DESCRIPTION
## Summary
- Adds DNS monitors: a resolver, an interval, a query, and a protocol (UDP, TCP, or DoT). The server sends the query on the interval and records the response time, the response code, and the error text.
- New `internal/dnsmonitor` package (probe and service), `dns_monitors` and `dns_results` tables in migration 022 for both SQLite and Postgres, and CRUD, status, and paginated history endpoints under a `dns` route group.
- A monitor moves between the normal, `down`, and `recovered` states. Each change sends a notification through the existing channels and rules, from two seeded events in the new `dns` category. Results are removed by the existing retention purge.
- Promotes `miekg/dns` to a direct dependency and bumps it to v1.1.73, which also drops two indirect dependencies the old version pulled in.

## Why
- Backend half of #270. A dead or slow resolver reads as "the internet is broken" while every other monitor stays green.
- The UI comes in a separate change, so this ships without a DNS tab.

## Testing
- [ ] `pnpm -C web lint`
- [ ] `pnpm -C web build`
- [x] Other: ran the built binary against a loopback DNS server. A scheduled check recorded 0.33 ms NOERROR and the `ok` state; a resolver on a closed port recorded `connection refused` and the `down` state; pointing that monitor back at the live resolver gave `recovered`. A create body with only a host gives an enabled monitor, and an unknown monitor id returns 404 on both the status and the history route. Postgres tests are left to CI.

## Screenshots (if UI)
- None, no UI in this change.

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [x] AI-assisted changes reviewed and edited by a human

Closes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS monitoring over UDP, TCP, and DNS-over-TLS.
  * Configure resolvers, queries, record types, intervals, and enabled status.
  * View monitor status, response times, response codes, and paginated check history.
  * Receive live updates and notifications when monitors go down or recover.
  * DNS results are included in historical-data cleanup reports.

* **Documentation**
  * Documented DNS monitor behavior, states, supported protocols, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->