### PR TITLE
feat(dns): add the DNS tab

### DIFF
--- a/web/src/api/dns.ts
+++ b/web/src/api/dns.ts
@@ -36,7 +36,8 @@ const jsonBody = (monitor: DNSMonitorInput): RequestInit => ({
 
 export const getDNSMonitors = async (): Promise<DNSMonitor[]> => {
   const response = await dnsFetch("/dns/monitors");
-  return response.json();
+  // an empty list comes back as null, so hand callers a list either way
+  return (await response.json()) ?? [];
 };
 
 export const createDNSMonitor = async (

--- a/web/src/api/dns.ts
+++ b/web/src/api/dns.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getApiUrl } from "@/utils/baseUrl";
+import {
+  DNSMonitor,
+  DNSMonitorInput,
+  DNSResult,
+  DNSUpdate,
+  PaginatedResponse,
+} from "@/types/types";
+
+// dnsFetch keeps the error text the API sends, so a rejected monitor shows the
+// field that was wrong instead of a generic message.
+const dnsFetch = async (
+  path: string,
+  init?: RequestInit,
+): Promise<Response> => {
+  const response = await fetch(getApiUrl(path), init);
+  if (!response.ok) {
+    const message = await response
+      .json()
+      .then((data) => data.error as string | undefined)
+      .catch(() => undefined);
+    throw new Error(message || "DNS monitor request failed");
+  }
+  return response;
+};
+
+const jsonBody = (monitor: DNSMonitorInput): RequestInit => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(monitor),
+});
+
+export const getDNSMonitors = async (): Promise<DNSMonitor[]> => {
+  const response = await dnsFetch("/dns/monitors");
+  return response.json();
+};
+
+export const createDNSMonitor = async (
+  monitor: DNSMonitorInput,
+): Promise<DNSMonitor> => {
+  const response = await dnsFetch("/dns/monitors", {
+    method: "POST",
+    ...jsonBody(monitor),
+  });
+  return response.json();
+};
+
+export const updateDNSMonitor = async (
+  monitor: DNSMonitorInput & { id: number },
+): Promise<DNSMonitor> => {
+  const response = await dnsFetch(`/dns/monitors/${monitor.id}`, {
+    method: "PUT",
+    ...jsonBody(monitor),
+  });
+  return response.json();
+};
+
+export const deleteDNSMonitor = async (id: number): Promise<void> => {
+  await dnsFetch(`/dns/monitors/${id}`, { method: "DELETE" });
+};
+
+export const getDNSMonitorStatus = async (id: number): Promise<DNSUpdate> => {
+  const response = await dnsFetch(`/dns/monitors/${id}/status`);
+  return response.json();
+};
+
+export const getDNSHistory = async (
+  id: number,
+  page: number = 1,
+  limit: number = 25,
+): Promise<PaginatedResponse<DNSResult>> => {
+  const response = await dnsFetch(
+    `/dns/monitors/${id}/history?page=${page}&limit=${limit}`,
+  );
+  return response.json();
+};

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -280,6 +280,8 @@ export const getEventCategoryIcon = (category: string): string => {
       return "📊";
     case "packetloss":
       return "📉";
+    case "dns":
+      return "🌐";
     case "agent":
       return "🖥️";
     default:

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -41,6 +41,7 @@ export interface DashboardSettings {
 export interface PurgeHistoryResult {
   speedTests: number;
   packetLoss: number;
+  dns: number;
 }
 
 export const settingsApi = {

--- a/web/src/components/Main.tsx
+++ b/web/src/components/Main.tsx
@@ -14,6 +14,7 @@ import { DashboardTab } from "./speedtest/DashboardTab";
 import { SpeedTestTab } from "./speedtest/SpeedTestTab";
 import { TracerouteTab } from "./speedtest/TracerouteTab";
 import { MonitorTab } from "./monitor/MonitorTab";
+import { DNSTab } from "./dns/DNSTab";
 import { showToast } from "@/components/common/Toast";
 import { getPublicTheme } from "@/api/license";
 import { applyPublicColorTheme } from "@/utils/colorTheme";
@@ -22,6 +23,7 @@ import {
   PlayIcon,
   GlobeAltIcon,
   ServerIcon,
+  ServerStackIcon,
 } from "@heroicons/react/24/outline";
 import {
   Server,
@@ -122,6 +124,11 @@ export default function Main({ isPublic = false }: MainProps) {
       id: "traceroute",
       label: "Traceroute",
       icon: <GlobeAltIcon className="w-5 h-5" />,
+    },
+    {
+      id: "dns",
+      label: "DNS",
+      icon: <ServerStackIcon className="w-5 h-5" />,
     },
     {
       id: "monitor",
@@ -608,6 +615,18 @@ export default function Main({ isPublic = false }: MainProps) {
               transition={{ duration: 0.3 }}
             >
               <TracerouteTab />
+            </motion.div>
+          )}
+
+          {!isPublic && activeTab === "dns" && (
+            <motion.div
+              key="dns"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <DNSTab />
             </motion.div>
           )}
 

--- a/web/src/components/common/DeleteMonitorModal.tsx
+++ b/web/src/components/common/DeleteMonitorModal.tsx
@@ -9,13 +9,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { PacketLossMonitor } from "@/types/types";
-
 interface DeleteMonitorModalProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
-  monitor: PacketLossMonitor | null;
+  // any monitor with a name and a host: packet loss and DNS both fit
+  monitor: { name?: string; host: string } | null;
 }
 
 export function DeleteMonitorModal({

--- a/web/src/components/common/TabNavigation.tsx
+++ b/web/src/components/common/TabNavigation.tsx
@@ -38,6 +38,11 @@ const TAB_COLORS = {
     inactive:
       "text-gray-500 dark:text-gray-400 hover:text-amber-500 dark:hover:text-amber-300",
   },
+  dns: {
+    active: "text-cyan-600 dark:text-cyan-400",
+    inactive:
+      "text-gray-500 dark:text-gray-400 hover:text-cyan-500 dark:hover:text-cyan-300",
+  },
   monitor: {
     active: "text-purple-600 dark:text-purple-400",
     inactive:

--- a/web/src/components/dns/DNSMonitorDetails.tsx
+++ b/web/src/components/dns/DNSMonitorDetails.tsx
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import React, { useMemo } from "react";
+import { motion } from "motion/react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  ClockIcon,
+  CheckCircleIcon,
+  SignalIcon,
+} from "@heroicons/react/24/outline";
+import { DNSMonitor, DNSUpdate } from "@/types/types";
+import { getDNSHistory } from "@/api/dns";
+import { MetricCard } from "@/components/common/MetricCard";
+import { formatters, formatDateTimeWithSettings } from "@/utils/timeSettings";
+import { stateBadge } from "./constants";
+
+interface DNSMonitorDetailsProps {
+  monitor: DNSMonitor;
+  status?: DNSUpdate;
+}
+
+export const DNSMonitorDetails: React.FC<DNSMonitorDetailsProps> = ({
+  monitor,
+  status,
+}) => {
+  const {
+    data: history,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteQuery({
+    queryKey: ["dns", "history", monitor.id],
+    queryFn: ({ pageParam }) => getDNSHistory(monitor.id, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((total, page) => total + page.data.length, 0);
+      return loaded < (lastPage.total || 0) ? lastPage.page + 1 : undefined;
+    },
+    refetchInterval: 10000,
+  });
+
+  // A new result at the top can push a row into the next page, so drop the
+  // repeats a refetch brings in.
+  const results = useMemo(() => {
+    const byID = new Map(
+      (history?.pages.flatMap((page) => page.data) ?? []).map((result) => [
+        result.id,
+        result,
+      ]),
+    );
+    return [...byID.values()];
+  }, [history]);
+
+  const totalCount = history?.pages[0]?.total ?? results.length;
+
+  const chartData = useMemo(
+    () =>
+      results
+        .slice(0, 30)
+        .reverse()
+        .map((result) => ({
+          time: formatters.chartTick(new Date(result.createdAt), "1d"),
+          responseTime: result.success ? result.responseTimeMs : null,
+        })),
+    [results],
+  );
+
+  // A disabled monitor polls no status, so the newest stored result stands in.
+  const latest = results[0];
+  // a live status replaces the stored result whole: its optional fields are
+  // absent on purpose, so a field-by-field fallback would keep stale values
+  const responseTimeMs = status ? status.responseTimeMs : latest?.responseTimeMs;
+  const responseCode = status ? status.responseCode : latest?.responseCode;
+  const success = status ? status.success : latest?.success;
+  const error = status ? status.error : latest?.error;
+  const badge = stateBadge(status?.state || monitor.lastState);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.1 }}
+      className="flex-1"
+    >
+      <div className="bg-gray-50/95 dark:bg-gray-850/95 rounded-xl p-6 shadow-lg border border-gray-200 dark:border-gray-800">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+          {monitor.name || monitor.host} Details
+        </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <MetricCard
+            icon={<ClockIcon className="w-5 h-5 text-blue-500" />}
+            title="Latency"
+            value={
+              success && responseTimeMs !== undefined
+                ? responseTimeMs.toFixed(1)
+                : "—"
+            }
+            unit="ms"
+            status="normal"
+          />
+          <MetricCard
+            icon={<CheckCircleIcon className="w-5 h-5 text-emerald-500" />}
+            title="Code"
+            value={responseCode || "—"}
+            unit=""
+            status={responseCode && !success ? "error" : "normal"}
+          />
+          <MetricCard
+            icon={<SignalIcon className="w-5 h-5 text-amber-500" />}
+            title="State"
+            value={badge?.label ?? "—"}
+            unit=""
+            status={
+              badge?.label === "Down"
+                ? "error"
+                : badge
+                  ? "success"
+                  : "normal"
+            }
+          />
+        </div>
+
+        {error && (
+          <div className="mb-6 p-3 rounded-lg border border-red-500/30 bg-red-500/10 text-sm text-red-600 dark:text-red-400 break-words">
+            {error}
+          </div>
+        )}
+
+        {chartData.length > 0 && (
+          <div className="mb-6">
+            <h3 className="text-gray-700 dark:text-gray-300 font-medium mb-2">
+              Latency History
+            </h3>
+            <p className="text-gray-600 dark:text-gray-400 text-xs mb-4">
+              Last {chartData.length} checks • failed checks leave a gap
+            </p>
+            <div className="h-64 bg-white/50 dark:bg-gray-900/50 rounded-lg p-4 border border-gray-200/50 dark:border-gray-700/50">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--color-gray-500, #6b7280)"
+                    strokeOpacity={0.15}
+                    strokeWidth={0.5}
+                  />
+                  <XAxis
+                    dataKey="time"
+                    stroke="var(--color-gray-400, #9ca3af)"
+                    fontSize={11}
+                    axisLine={false}
+                    tickLine={false}
+                    dy={10}
+                  />
+                  <YAxis
+                    stroke="var(--color-gray-400, #9ca3af)"
+                    fontSize={11}
+                    axisLine={false}
+                    tickLine={false}
+                    label={{
+                      value: "Response (ms)",
+                      angle: -90,
+                      position: "insideLeft",
+                      style: {
+                        fill: "var(--color-gray-400, #9ca3af)",
+                        textAnchor: "middle",
+                      },
+                    }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "var(--tooltip-bg)",
+                      border: "1px solid var(--tooltip-border)",
+                      borderRadius: "0.5rem",
+                      boxShadow: "0 10px 15px -3px rgba(0, 0, 0, 0.1)",
+                    }}
+                    labelStyle={{
+                      color: "var(--tooltip-label)",
+                      fontSize: "12px",
+                      fontWeight: "medium",
+                    }}
+                    itemStyle={{ color: "var(--tooltip-text)" }}
+                    formatter={(value) =>
+                      typeof value === "number"
+                        ? `${value.toFixed(1)} ms`
+                        : String(value ?? "")
+                    }
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="responseTime"
+                    stroke="var(--color-blue-500, #3b82f6)"
+                    strokeWidth={2.5}
+                    name="Response Time"
+                    connectNulls={false}
+                    // the panel polls, and a redraw animation on every poll
+                    // reads as a flicker
+                    isAnimationActive={false}
+                    dot={{
+                      fill: "var(--color-blue-500, #3b82f6)",
+                      strokeWidth: 0,
+                      r: 3,
+                    }}
+                    activeDot={{
+                      r: 5,
+                      stroke: "var(--color-blue-500, #3b82f6)",
+                      strokeWidth: 2,
+                    }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        )}
+
+        <h3 className="text-gray-700 dark:text-gray-300 font-medium mb-3">
+          Recent Results {totalCount > 0 && `(${totalCount} total)`}
+        </h3>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">Loading...</p>
+        ) : results.length === 0 ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            No checks recorded yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-300 dark:border-gray-800">
+                  <th className="text-left py-2 px-3 text-gray-600 dark:text-gray-400 font-medium">
+                    Time
+                  </th>
+                  <th className="text-center py-2 px-3 text-gray-600 dark:text-gray-400 font-medium">
+                    Response
+                  </th>
+                  <th className="text-center py-2 px-3 text-gray-600 dark:text-gray-400 font-medium">
+                    Code
+                  </th>
+                  <th className="text-left py-2 px-3 text-gray-600 dark:text-gray-400 font-medium">
+                    Error
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((result) => (
+                  <tr
+                    key={result.id}
+                    className="border-b border-gray-300/50 dark:border-gray-800/50 hover:bg-gray-200/30 dark:hover:bg-gray-800/30 transition-colors"
+                  >
+                    <td className="py-2 px-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                      {formatDateTimeWithSettings(result.createdAt)}
+                    </td>
+                    <td
+                      className={`py-2 px-3 text-center font-mono ${
+                        result.success
+                          ? "text-blue-600 dark:text-blue-400"
+                          : "text-red-600 dark:text-red-400"
+                      }`}
+                    >
+                      {result.success
+                        ? `${result.responseTimeMs.toFixed(1)}ms`
+                        : "failed"}
+                    </td>
+                    <td className="py-2 px-3 text-center text-gray-600 dark:text-gray-400">
+                      {result.responseCode || "—"}
+                    </td>
+                    <td className="py-2 px-3 text-red-600 dark:text-red-400 break-words">
+                      {result.error || ""}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {hasNextPage && (
+              <div className="flex justify-center mt-4">
+                <button
+                  onClick={() => void fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                  className="px-4 py-2 bg-gray-200/30 dark:bg-gray-800/30 border border-gray-300/50 dark:border-gray-900/50 text-gray-600/50 dark:text-gray-300/50 hover:text-gray-700 dark:hover:text-gray-300 rounded-lg hover:bg-gray-300/50 dark:hover:bg-gray-800/50 transition-colors"
+                >
+                  {isFetchingNextPage ? "Loading..." : "Load More"}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/web/src/components/dns/DNSMonitorForm.tsx
+++ b/web/src/components/dns/DNSMonitorForm.tsx
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DNSMonitor, DNSMonitorInput, DNSProtocol } from "@/types/types";
+import { intervalOptions } from "@/components/speedtest/packetloss/constants/packetLossConstants";
+import { formatInterval } from "@/components/speedtest/packetloss/utils/packetLossUtils";
+import { protocolOptions, recordTypes, resolverPresets } from "./constants";
+
+interface DNSMonitorFormProps {
+  showForm: boolean;
+  onClose: () => void;
+  onSubmit: (data: DNSMonitorInput) => void;
+  editingMonitor?: DNSMonitor | null;
+  formData: DNSMonitorInput;
+  onFormDataChange: (data: DNSMonitorInput) => void;
+  isLoading?: boolean;
+}
+
+export const DNSMonitorForm: React.FC<DNSMonitorFormProps> = ({
+  showForm,
+  onClose,
+  onSubmit,
+  editingMonitor,
+  formData,
+  onFormDataChange,
+  isLoading = false,
+}) => {
+  // the resolver input is `required`, so the browser blocks an empty submit
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ ...formData, host: formData.host.trim() });
+  };
+
+  return (
+    <Dialog open={showForm} onOpenChange={onClose}>
+      <DialogContent className="w-full max-w-md bg-white dark:bg-gray-850 border dark:border-gray-900 max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+            {editingMonitor ? "Edit DNS Monitor" : "New DNS Monitor"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label className="mb-2">Presets</Label>
+            <div className="flex flex-wrap gap-2">
+              {resolverPresets.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() =>
+                    onFormDataChange({
+                      ...formData,
+                      host: preset.host,
+                      protocol: preset.protocol,
+                      name: formData.name.trim() || preset.label,
+                    })
+                  }
+                  className={`px-2.5 py-1 rounded-md text-xs border transition-colors ${
+                    formData.host === preset.host &&
+                    formData.protocol === preset.protocol
+                      ? "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/30"
+                      : "bg-gray-200/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-800 hover:bg-gray-300/50 dark:hover:bg-gray-700/50"
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Label>Resolver</Label>
+            <Input
+              type="text"
+              value={formData.host}
+              onChange={(e) =>
+                onFormDataChange({ ...formData, host: e.target.value })
+              }
+              placeholder="e.g., 192.168.1.1 or dns.example.com:5353"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              autoComplete="off"
+              required
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+              Port 53 by default, 853 for DNS over TLS. Add :port to override.
+            </p>
+          </div>
+
+          <div>
+            <Label>Name</Label>
+            <Input
+              type="text"
+              value={formData.name}
+              onChange={(e) =>
+                onFormDataChange({ ...formData, name: e.target.value })
+              }
+              placeholder="e.g., Pi-hole"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              autoComplete="off"
+            />
+          </div>
+
+          <div>
+            <Label>Protocol</Label>
+            <Select
+              value={formData.protocol}
+              onValueChange={(value) =>
+                onFormDataChange({
+                  ...formData,
+                  protocol: value as DNSProtocol,
+                })
+              }
+            >
+              <SelectTrigger className="w-full bg-gray-200/50 dark:bg-gray-800/50 border-gray-300 dark:border-gray-900">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {protocolOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label>Query</Label>
+            <Input
+              type="text"
+              value={formData.query}
+              onChange={(e) =>
+                onFormDataChange({ ...formData, query: e.target.value })
+              }
+              placeholder="google.com"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              autoComplete="off"
+            />
+          </div>
+
+          <div>
+            <Label>Record Type</Label>
+            <Select
+              value={formData.recordType}
+              onValueChange={(value) =>
+                onFormDataChange({ ...formData, recordType: value })
+              }
+            >
+              <SelectTrigger className="w-full bg-gray-200/50 dark:bg-gray-800/50 border-gray-300 dark:border-gray-900">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {recordTypes.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label>Check Interval</Label>
+            <Select
+              value={formData.interval}
+              onValueChange={(value) =>
+                onFormDataChange({ ...formData, interval: value })
+              }
+            >
+              <SelectTrigger className="w-full bg-gray-200/50 dark:bg-gray-800/50 border-gray-300 dark:border-gray-900">
+                <SelectValue>
+                  {intervalOptions.find(
+                    (option) => option.value === formData.interval,
+                  )?.label || `Every ${formatInterval(formData.interval)}`}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {intervalOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="dns-enabled"
+              checked={formData.enabled}
+              onCheckedChange={(checked) =>
+                onFormDataChange({ ...formData, enabled: checked as boolean })
+              }
+            />
+            <Label htmlFor="dns-enabled" className="cursor-pointer">
+              Start monitoring immediately
+            </Label>
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <Button
+              type="submit"
+              disabled={isLoading}
+              isLoading={isLoading}
+              variant="default"
+              className="flex-1"
+            >
+              {editingMonitor ? "Update Monitor" : "Create Monitor"}
+            </Button>
+            <Button type="button" onClick={onClose} variant="secondary">
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/components/dns/DNSTab.tsx
+++ b/web/src/components/dns/DNSTab.tsx
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import React, { useState } from "react";
+import { motion } from "motion/react";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  GlobeAltIcon,
+  PencilIcon,
+  PlayIcon,
+  StopIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline";
+import { DNSMonitor, DNSMonitorInput, DNSUpdate } from "@/types/types";
+import {
+  createDNSMonitor,
+  deleteDNSMonitor,
+  getDNSMonitors,
+  getDNSMonitorStatus,
+  updateDNSMonitor,
+} from "@/api/dns";
+import { Button } from "@/components/ui/Button";
+import { showToast } from "@/components/common/Toast";
+import { DeleteMonitorModal } from "@/components/common/DeleteMonitorModal";
+import { formatInterval } from "@/components/speedtest/packetloss/utils/packetLossUtils";
+import { DNSMonitorForm } from "./DNSMonitorForm";
+import { DNSMonitorDetails } from "./DNSMonitorDetails";
+import { defaultDNSFormData, stateBadge } from "./constants";
+
+export const DNSTab: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingMonitor, setEditingMonitor] = useState<DNSMonitor | null>(null);
+  const [formData, setFormData] = useState<DNSMonitorInput>(defaultDNSFormData);
+  const [monitorToDelete, setMonitorToDelete] = useState<DNSMonitor | null>(
+    null,
+  );
+
+  const { data: monitors = [], isLoading } = useQuery({
+    queryKey: ["dns", "monitors"],
+    queryFn: getDNSMonitors,
+    staleTime: 30000,
+  });
+
+  const selectedMonitor =
+    monitors.find((monitor) => monitor.id === selectedId) ?? null;
+
+  // Live status: the server has no event stream for DNS, so each enabled
+  // monitor polls its own status route.
+  const statuses = useQueries({
+    queries: monitors
+      .filter((monitor) => monitor.enabled)
+      .map((monitor) => ({
+        queryKey: ["dns", "status", monitor.id],
+        queryFn: () => getDNSMonitorStatus(monitor.id),
+        refetchInterval: 5000,
+      })),
+    combine: (results) =>
+      new Map<number, DNSUpdate>(
+        results.flatMap((result) =>
+          result.data ? [[result.data.monitorId, result.data] as const] : [],
+        ),
+      ),
+  });
+
+  const refreshMonitors = () =>
+    queryClient.invalidateQueries({ queryKey: ["dns", "monitors"] });
+
+  const createMutation = useMutation({
+    mutationFn: createDNSMonitor,
+    onSuccess: (monitor) => {
+      void refreshMonitors();
+      showToast("DNS monitor created", "success", {
+        description: `Monitoring ${monitor.host}`,
+      });
+      handleCancelForm();
+    },
+    onError: (error: Error) => {
+      showToast("Failed to create DNS monitor", "error", {
+        description: error.message,
+      });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateDNSMonitor,
+    onSuccess: (monitor) => {
+      void refreshMonitors();
+      void queryClient.invalidateQueries({
+        queryKey: ["dns", "status", monitor.id],
+      });
+      if (editingMonitor) {
+        showToast("DNS monitor updated", "success", {
+          description: monitor.name || monitor.host,
+        });
+        handleCancelForm();
+      }
+    },
+    onError: (error: Error) => {
+      showToast("Failed to update DNS monitor", "error", {
+        description: error.message,
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteDNSMonitor,
+    onSuccess: (_, monitorId) => {
+      void refreshMonitors();
+      if (selectedId === monitorId) {
+        setSelectedId(null);
+      }
+      showToast("DNS monitor deleted", "success");
+    },
+    onError: (error: Error) => {
+      showToast("Failed to delete DNS monitor", "error", {
+        description: error.message,
+      });
+    },
+  });
+
+  const handleSubmit = (data: DNSMonitorInput) => {
+    if (editingMonitor) {
+      updateMutation.mutate({ ...data, id: editingMonitor.id });
+    } else {
+      createMutation.mutate(data);
+    }
+  };
+
+  const handleEdit = (monitor: DNSMonitor) => {
+    setEditingMonitor(monitor);
+    setFormData(monitor);
+    setShowForm(true);
+  };
+
+  const handleCancelForm = () => {
+    setShowForm(false);
+    setEditingMonitor(null);
+    setFormData(defaultDNSFormData);
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row gap-6 md:items-start">
+      {/* Left Column - Monitor List */}
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.2 }}
+        className="flex-1"
+      >
+        <div className="bg-gray-50/95 dark:bg-gray-850/95 rounded-xl p-6 shadow-lg border border-gray-200 dark:border-gray-800">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                DNS Monitors
+              </h2>
+              <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
+                Response time and failures per resolver
+              </p>
+            </div>
+
+            <Button onClick={() => setShowForm(true)} variant="default">
+              Add
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <div className="text-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400 mx-auto"></div>
+              <p className="text-gray-600 dark:text-gray-400 mt-4">
+                Loading monitors...
+              </p>
+            </div>
+          ) : monitors.length === 0 ? (
+            <div className="text-center py-8">
+              <GlobeAltIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+              <p className="text-gray-600 dark:text-gray-400">
+                No DNS monitors configured yet
+              </p>
+              <p className="text-gray-500 dark:text-gray-500 text-sm mt-2">
+                Add a monitor to watch a resolver
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {monitors.map((monitor) => {
+                const status = statuses.get(monitor.id);
+                // a disabled monitor polls no status, so its stored state
+                // fills the badge
+                const badge = stateBadge(status?.state || monitor.lastState);
+
+                return (
+                  <div
+                    key={monitor.id}
+                    className={`p-4 rounded-lg border transition-all cursor-pointer ${
+                      selectedId === monitor.id
+                        ? "bg-blue-500/10 border-blue-400/50 shadow-lg"
+                        : "bg-gray-200/50 dark:bg-gray-800/50 border-gray-300 dark:border-gray-800 hover:bg-gray-300/50 dark:hover:bg-gray-800 hover:shadow-md"
+                    }`}
+                    onClick={() =>
+                      setSelectedId(
+                        selectedId === monitor.id ? null : monitor.id,
+                      )
+                    }
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2 flex-wrap">
+                          <h3 className="text-gray-900 dark:text-white font-semibold truncate">
+                            {monitor.name || monitor.host}
+                          </h3>
+                          <span
+                            className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
+                              monitor.enabled
+                                ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20"
+                                : "bg-gray-500/10 text-gray-600 dark:text-gray-400 border border-gray-500/20"
+                            }`}
+                          >
+                            {monitor.enabled ? (
+                              <span className="relative inline-flex h-1.5 w-1.5 mr-1.5">
+                                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500"></span>
+                              </span>
+                            ) : (
+                              <div className="w-1.5 h-1.5 rounded-full mr-1.5 bg-gray-400" />
+                            )}
+                            {monitor.enabled ? "Active" : "Stopped"}
+                          </span>
+                          {badge && (
+                            <span
+                              className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium border ${badge.className}`}
+                            >
+                              {badge.label}
+                            </span>
+                          )}
+                        </div>
+
+                        {monitor.name && (
+                          <p className="text-gray-600 dark:text-gray-400 text-sm mb-2 truncate">
+                            {monitor.host}
+                          </p>
+                        )}
+
+                        <div className="flex flex-wrap mt-3 gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-400">
+                          <span>
+                            {monitor.protocol === "dot"
+                              ? "DoT"
+                              : monitor.protocol.toUpperCase()}
+                          </span>
+                          <span>
+                            {monitor.recordType} {monitor.query}
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* Action Buttons */}
+                      <div className="flex items-center gap-1 ml-4">
+                        <button
+                          className={`p-1.5 rounded-md transition-colors duration-200 ${
+                            monitor.enabled
+                              ? "hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 hover:text-red-600 dark:text-red-400"
+                              : "hover:bg-emerald-100 dark:hover:bg-emerald-900/30 text-emerald-600 hover:text-emerald-700 dark:text-emerald-400"
+                          }`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            updateMutation.mutate({
+                              ...monitor,
+                              enabled: !monitor.enabled,
+                            });
+                          }}
+                          disabled={updateMutation.isPending}
+                          title={
+                            monitor.enabled ? "Stop Monitor" : "Start Monitor"
+                          }
+                        >
+                          {monitor.enabled ? (
+                            <StopIcon className="w-3.5 h-3.5" />
+                          ) : (
+                            <PlayIcon className="w-3.5 h-3.5" />
+                          )}
+                        </button>
+                        <button
+                          className="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-900/30 text-gray-500 hover:text-gray-600 dark:text-gray-400 transition-colors duration-200"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleEdit(monitor);
+                          }}
+                          title="Edit Monitor"
+                        >
+                          <PencilIcon className="w-3.5 h-3.5" />
+                        </button>
+                        <button
+                          className="p-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 hover:text-red-600 dark:text-red-400 transition-colors duration-200"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setMonitorToDelete(monitor);
+                          }}
+                          title="Delete Monitor"
+                        >
+                          <TrashIcon className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 pt-3 border-t border-gray-300 dark:border-gray-700 flex items-center justify-between gap-2">
+                      <span
+                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs border ${
+                          monitor.enabled
+                            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20"
+                            : "bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20"
+                        }`}
+                      >
+                        Every {formatInterval(monitor.interval)}
+                      </span>
+                      {monitor.enabled && badge && status && (
+                        <span
+                          className={`text-xs font-mono ${
+                            status.success
+                              ? "text-blue-600 dark:text-blue-400"
+                              : "text-red-600 dark:text-red-400"
+                          }`}
+                        >
+                          {status.success
+                            ? `${(status.responseTimeMs ?? 0).toFixed(1)} ms`
+                            : status.responseCode || "failed"}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </motion.div>
+
+      {/* Right Column - Monitor Details */}
+      {selectedMonitor && (
+        <DNSMonitorDetails
+          key={selectedMonitor.id}
+          monitor={selectedMonitor}
+          status={statuses.get(selectedMonitor.id)}
+        />
+      )}
+
+      <DNSMonitorForm
+        showForm={showForm}
+        onClose={handleCancelForm}
+        onSubmit={handleSubmit}
+        editingMonitor={editingMonitor}
+        formData={formData}
+        onFormDataChange={setFormData}
+        isLoading={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <DeleteMonitorModal
+        isOpen={monitorToDelete !== null}
+        onClose={() => setMonitorToDelete(null)}
+        onConfirm={() => {
+          if (monitorToDelete) {
+            deleteMutation.mutate(monitorToDelete.id);
+          }
+        }}
+        monitor={monitorToDelete}
+      />
+    </div>
+  );
+};

--- a/web/src/components/dns/constants.ts
+++ b/web/src/components/dns/constants.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { DNSMonitorInput, DNSProtocol } from "@/types/types";
+
+export const protocolOptions: { value: DNSProtocol; label: string }[] = [
+  { value: "udp", label: "UDP" },
+  { value: "tcp", label: "TCP" },
+  { value: "dot", label: "DNS over TLS" },
+];
+
+export const recordTypes = ["A", "AAAA", "CNAME", "MX", "NS", "TXT"];
+
+// Quick-picks for well-known public resolvers. They only prefill the form; the
+// resolver field stays free text.
+export const resolverPresets: {
+  label: string;
+  host: string;
+  protocol: DNSProtocol;
+}[] = [
+  { label: "Cloudflare", host: "1.1.1.1", protocol: "udp" },
+  { label: "Cloudflare DoT", host: "one.one.one.one", protocol: "dot" },
+  { label: "Google", host: "8.8.8.8", protocol: "udp" },
+  { label: "Google DoT", host: "dns.google", protocol: "dot" },
+  { label: "Quad9", host: "9.9.9.9", protocol: "udp" },
+  { label: "Quad9 DoT", host: "dns.quad9.net", protocol: "dot" },
+  { label: "OpenDNS", host: "208.67.222.222", protocol: "udp" },
+  { label: "OpenDNS DoT", host: "dns.opendns.com", protocol: "dot" },
+];
+
+// Badges for the states the server reports. A monitor that has not run yet is
+// in the "unknown" state and gets no badge.
+const STATE_BADGES: Record<string, { label: string; className: string }> = {
+  ok: {
+    label: "OK",
+    className:
+      "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+  },
+  down: {
+    label: "Down",
+    className: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20",
+  },
+  recovered: {
+    label: "Recovered",
+    className:
+      "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+  },
+};
+
+export const stateBadge = (state?: string) => STATE_BADGES[state ?? ""] ?? null;
+
+export const defaultDNSFormData: DNSMonitorInput = {
+  host: "",
+  name: "",
+  protocol: "udp",
+  query: "google.com",
+  recordType: "A",
+  interval: "1m",
+  enabled: true,
+};

--- a/web/src/components/settings/DataSettings.tsx
+++ b/web/src/components/settings/DataSettings.tsx
@@ -39,8 +39,9 @@ export const DataSettings: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ["history"] });
       queryClient.invalidateQueries({ queryKey: ["history-chart"] });
       queryClient.invalidateQueries({ queryKey: ["packetloss"] });
+      queryClient.invalidateQueries({ queryKey: ["dns"] });
       showToast("History purged", "success", {
-        description: `Deleted ${result.speedTests} speedtests and ${result.packetLoss} packet loss records`,
+        description: `Deleted ${result.speedTests} speedtests, ${result.packetLoss} packet loss records and ${result.dns} DNS results`,
       });
     },
     onError: (err: unknown) => {

--- a/web/src/components/settings/notifications/EventCategorySection.tsx
+++ b/web/src/components/settings/notifications/EventCategorySection.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRightIcon,
   RocketLaunchIcon,
   SignalIcon,
+  ServerStackIcon,
   ComputerDesktopIcon,
   BellIcon
 } from "@heroicons/react/24/outline";
@@ -48,7 +49,10 @@ export const EventCategorySection: React.FC<EventCategorySectionProps> = ({
   onUpdateRule,
 }) => {
 
-  const categoryTitle = category.charAt(0).toUpperCase() + category.slice(1);
+  const categoryTitle =
+    category === "dns"
+      ? "DNS"
+      : category.charAt(0).toUpperCase() + category.slice(1);
   
   // Get category icon component
   const getCategoryIcon = () => {
@@ -57,6 +61,8 @@ export const EventCategorySection: React.FC<EventCategorySectionProps> = ({
         return <RocketLaunchIcon className="w-6 h-6 text-blue-600 dark:text-blue-400" />;
       case "packetloss":
         return <SignalIcon className="w-6 h-6 text-amber-600 dark:text-amber-400" />;
+      case "dns":
+        return <ServerStackIcon className="w-6 h-6 text-cyan-600 dark:text-cyan-400" />;
       case "agent":
         return <ComputerDesktopIcon className="w-6 h-6 text-emerald-600 dark:text-emerald-400" />;
       default:
@@ -74,6 +80,7 @@ export const EventCategorySection: React.FC<EventCategorySectionProps> = ({
   const categoryStyles = {
     speedtest: "border-blue-500/30 bg-blue-500/5",
     packetloss: "border-amber-500/30 bg-amber-500/5",
+    dns: "border-cyan-500/30 bg-cyan-500/5",
     agent: "border-emerald-500/30 bg-emerald-500/5",
   };
 

--- a/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
+++ b/web/src/components/speedtest/packetloss/PacketLossMonitorList.tsx
@@ -16,7 +16,7 @@ import {
 import { PacketLossMonitor } from "@/types/types";
 import { formatTimeWithSettings } from "@/utils/timeSettings";
 import { formatInterval } from "./utils/packetLossUtils";
-import { DeleteMonitorModal } from "./DeleteMonitorModal";
+import { DeleteMonitorModal } from "@/components/common/DeleteMonitorModal";
 import { MonitorStatus } from "./types/monitorStatus";
 
 interface MonitorStatusDisplayProps {

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -218,3 +218,49 @@ export interface PacketLossUpdate {
   hopCount?: number;
   error?: string;
 }
+
+export type DNSProtocol = "udp" | "tcp" | "dot";
+
+// The host holds an optional ":port". Without one the server uses port 53, or
+// port 853 for DoT.
+export interface DNSMonitorInput {
+  host: string;
+  name: string;
+  protocol: DNSProtocol;
+  query: string;
+  recordType: string;
+  interval: string;
+  enabled: boolean;
+}
+
+export interface DNSMonitor extends DNSMonitorInput {
+  id: number;
+  lastRun?: string | null;
+  nextRun?: string | null;
+  lastState?: string;
+  lastStateChange?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DNSResult {
+  id: number;
+  monitorId: number;
+  responseTimeMs: number;
+  responseCode: string;
+  success: boolean;
+  error?: string;
+  createdAt: string;
+}
+
+// DNSUpdate is the last known result of a monitor, not the progress of a
+// running check. State is "unknown" until the first check, then "ok", "down",
+// or "recovered".
+export interface DNSUpdate {
+  monitorId: number;
+  success: boolean;
+  responseTimeMs?: number;
+  responseCode?: string;
+  state?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- Adds the DNS tab: monitor list, create/edit/enable/delete form with resolver presets, status cards, latency history chart, and paginated results.
- Stacked on `feat/dns-monitor-backend` (#273). GitHub retargets this to `develop` when that merges.

## Why
- The backend records DNS checks but nothing shows them. This is the UI half of #270.

## Testing
- [ ] `pnpm -C web lint`
- [x] `pnpm -C web build`
- [x] Other: ran the built binary against a local SQLite database with two monitors, one healthy resolver (1.1.1.1) and one dead resolver (127.0.0.1:5999). Created a monitor from a preset, edited it, stopped and started it, and deleted it. Watched the card go to `down` and the detail panel show the transport error, the empty chart, and the failed rows.

## Screenshots (if UI)
<img width="1036" height="1166" alt="dns-tab-monitor-form" src="https://github.com/user-attachments/assets/43631be2-6f1c-4e57-8349-697a38141780" />
<img width="1064" height="1144" alt="dns-tab-monitor-details" src="https://github.com/user-attachments/assets/0fbafaf4-57c5-44d6-80b0-1fb3e722d08b" />
<img width="1064" height="1144" alt="dns-tab-down-monitor" src="https://github.com/user-attachments/assets/b37f909d-cac5-4a8a-8baa-ded3d5ba8ed7" />


## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [ ] AI-assisted changes reviewed and edited by a human

Closes #272
