### PR TITLE
fix(update): give the self-updater a checksums asset it can find

### DIFF
--- a/.config/goreleaser.yml
+++ b/.config/goreleaser.yml
@@ -114,7 +114,9 @@ release:
     - Building from source with CGO enabled
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  # Keep this name free of the version. The self-updater must name the checksums
+  # asset before it knows which version it is about to download.
+  name_template: "checksums.txt"
 
 changelog:
   sort: asc

--- a/.config/goreleaser.yml
+++ b/.config/goreleaser.yml
@@ -115,7 +115,9 @@ release:
 
 checksum:
   # Keep this name free of the version. The self-updater must name the checksums
-  # asset before it knows which version it is about to download.
+  # asset before it knows which version it is about to download, and it writes the
+  # same name in cmd/netronome/update.go.
+  # See docs/adr/0002-fixed-checksums-asset-name.md.
   name_template: "checksums.txt"
 
 changelog:

--- a/cmd/netronome/update.go
+++ b/cmd/netronome/update.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/rs/zerolog/log"
@@ -27,8 +26,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// Create GitHub repository source
 	repo := selfupdate.ParseSlug("autobrr/netronome")
 
-	// First, detect the latest release without validation to get the version
-	updater, err := selfupdate.NewUpdater(selfupdate.Config{})
+	// The validator must be set before DetectLatest. DetectLatest records the ID of the
+	// checksums asset only when the updater has a validator, and UpdateTo cannot download
+	// the checksums without that ID.
+	updater, err := selfupdate.NewUpdater(selfupdate.Config{
+		Validator: &selfupdate.ChecksumValidator{UniqueFilename: "checksums.txt"},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create updater: %w", err)
 	}
@@ -58,18 +61,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		Str("latest_version", release.Version()).
 		Msg("New version available")
 
-	// Now create updater with correct checksum filename
-	versionStr := strings.TrimPrefix(release.Version(), "v")
-
-	updaterWithChecksum, err := selfupdate.NewUpdater(selfupdate.Config{
-		Validator: &selfupdate.ChecksumValidator{
-			UniqueFilename: fmt.Sprintf("netronome_%s_checksums.txt", versionStr),
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create updater with checksum: %w", err)
-	}
-
 	// Perform the update
 	exe, err := selfupdate.ExecutablePath()
 	if err != nil {
@@ -78,7 +69,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	log.Info().Str("path", exe).Msg("Updating binary...")
 
-	if err := updaterWithChecksum.UpdateTo(cmd.Context(), release, exe); err != nil {
+	if err := updater.UpdateTo(cmd.Context(), release, exe); err != nil {
 		return fmt.Errorf("failed to update: %w", err)
 	}
 

--- a/cmd/netronome/update.go
+++ b/cmd/netronome/update.go
@@ -29,6 +29,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// The validator must be set before DetectLatest. DetectLatest records the ID of the
 	// checksums asset only when the updater has a validator, and UpdateTo cannot download
 	// the checksums without that ID.
+	//
+	// This name must stay equal to checksum.name_template in .config/goreleaser.yml.
+	// See docs/adr/0002-fixed-checksums-asset-name.md.
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
 		Validator: &selfupdate.ChecksumValidator{UniqueFilename: "checksums.txt"},
 	})

--- a/docs/adr/0002-fixed-checksums-asset-name.md
+++ b/docs/adr/0002-fixed-checksums-asset-name.md
@@ -1,0 +1,53 @@
+# ADR-0002: The checksums asset has a fixed name
+
+Date: 2026-09-01
+Status: accepted
+PR: #277
+
+## Context
+
+`netronome update` replaces the binary of the agent or the server with the latest
+release. The `go-selfupdate` library downloads the archive, then reads a checksums
+file from the same release to make sure that the archive is correct.
+
+The library needs the name of the checksums asset before it looks at the release.
+`DetectLatest` records the ID of that asset only when the updater already holds a
+validator, and the validator holds the name. A release found without a validator
+keeps the value `-1` for the ID, and the download of the checksums then asks GitHub
+for asset `-1`, which always answers 404.
+
+The name of the checksums asset was `netronome_<version>_checksums.txt`. The version
+is not known before `DetectLatest`, so the correct name was not known before the
+updater had to be built. Every self-update failed for this reason.
+
+## Decision
+
+**The checksums asset is `checksums.txt`. The name does not contain the version.**
+`checksum.name_template` in `.config/goreleaser.yml` sets this name.
+
+**`cmd/netronome/update.go` writes the same name as a constant** in the
+`ChecksumValidator` of the one updater that it builds. With a name that does not
+change, the updater holds the validator from the start, and one `DetectLatest` gives
+a release that `UpdateTo` can download and check.
+
+The two files must always hold the same string. Nothing in the build finds a
+difference between them: a change to one of the two makes the self-update fail on the
+machine of the user, after the release, with a message about a validation asset that
+the release does not contain. Change the two files together.
+
+## Consequences
+
+The name of the checksums asset in a release is different from the names in the
+releases before v0.14.0. A person or a script that downloads
+`netronome_<version>_checksums.txt` must use `checksums.txt` for the new releases.
+The old releases keep their old names.
+
+An installation from a release before this change cannot update itself. Its binary
+looks for the old name, which the new releases do not contain, and it failed with the
+`-1` fault before this change. Such an installation needs one manual installation of
+a new binary. After that, `netronome update` works.
+
+This decision does not stop a move to `Updater.UpdateSelf`, which does the detection,
+the comparison of versions and the update in one call. `UpdateSelf` reads the version
+of the running binary as a semantic version, and a development build has the version
+`dev`, which is not one. That change is possible, but it is not part of this decision.


### PR DESCRIPTION
`netronome update` has always failed with `failed reading validation data "": ... GET /releases/assets/-1: 404 Not Found`.

`DetectLatest` records the ID of the checksums asset only when the updater already holds a validator. The updater was built with an empty config, so the release it returned kept the `-1` sentinel, and the second, validator-configured updater was then handed that stale release.

The validator has to name the checksums asset before the version is known, so the name can no longer carry the version. `checksum.name_template` becomes `checksums.txt`, and one updater built with the validator up front does both the detect and the update. ADR-0002 records that the name in the release config and the name in `update.go` must stay equal, because nothing in the build finds a difference between them.

Self-update is broken on every released binary today, so nothing regresses: an existing install fails on asset `-1` before and fails on a missing versioned checksums file after. Either way it needs one manual reinstall, and self-update works from the first release that carries `checksums.txt`.

## How has this been tested?

Three parts, none of which CI asserts on its own:

- Reproduced the fault: built with `-ldflags "-X main.version=0.4.1"` and ran `netronome update` against the live repository, which gave the `asset ID -1` 404.
- Exercised the fixed path: same build against a project that already publishes `checksums.txt`. The updater downloaded the archive and passed checksum validation, failing only because that archive holds a differently named binary.
- Confirmed the asset name: the goreleaser build on this PR lists `{"name":"checksums.txt","path":"dist/checksums.txt","type":"Checksum"}` in its artifact manifest.

The two halves have not run together, and cannot until a release carries the new name. The first real end-to-end test is the first `netronome update` after the next release.

No unit test. The function is a single GitHub API conversation end to end, so a test would have to mock the whole release source for a change this size.