### PR TITLE
ci: give the GoReleaser job its own Go build cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Cache Go modules
-        uses: actions/cache@v6
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Install dependencies
         run: go mod download
 
@@ -145,11 +137,24 @@ jobs:
           name: web-dist
           path: web/dist
 
+      # setup-go keys only on go.sum, so the test job's native cache wins this
+      # key and blocks the save here. A separate namespace keeps the
+      # cross-compile build cache.
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: false
+
+      - name: Cache Go cross-compile build cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-goreleaser-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-goreleaser-${{ env.GO_VERSION }}-
 
       - name: Run GoReleaser build
         if: github.event_name == 'pull_request'
@@ -157,7 +162,9 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --skip=validate,publish --parallelism 5
+          # One slot per build target. Fewer slots make a second wave that
+          # leaves most of the runner idle.
+          args: release --clean --skip=validate,publish --parallelism 7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDER: ${{ github.actor }}@github-actions
@@ -169,7 +176,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --parallelism 7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDER: ${{ github.actor }}@github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,9 +137,10 @@ jobs:
           name: web-dist
           path: web/dist
 
-      # setup-go keys only on go.sum, so the test job's native cache wins this
+      # setup-go keys only on go.mod, so the test job's native cache wins that
       # key and blocks the save here. A separate namespace keeps the
-      # cross-compile build cache.
+      # cross-compile build cache. Pull request runs cannot read each other's
+      # caches, so the entry that matters is the one a develop push writes.
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
@@ -156,15 +157,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-goreleaser-${{ env.GO_VERSION }}-
 
+      # Branch pushes build too, not just pull requests. A develop push is what
+      # writes the cache every pull request restores from, and a run that built
+      # nothing would store an empty one under that key and never replace it.
       - name: Run GoReleaser build
-        if: github.event_name == 'pull_request'
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
-          # One slot per build target. Fewer slots make a second wave that
-          # leaves most of the runner idle.
-          args: release --clean --skip=validate,publish --parallelism 7
+          args: release --clean --skip=validate,publish --parallelism 5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDER: ${{ github.actor }}@github-actions
@@ -176,7 +178,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --parallelism 7
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDER: ${{ github.actor }}@github-actions


### PR DESCRIPTION
## Summary
- Move the GoReleaser job's Go cache into its own `actions/cache` key namespace, so the cross-compile build cache is actually saved.
- Run the non-publishing GoReleaser build on branch pushes, not only on pull requests, so a develop push writes the cache that pull requests restore from.
- Delete the manual module cache in the test job, which `setup-go` already covers.

Measured on this PR: the `Run GoReleaser build` step goes from 12m04s to 1m16s, and the whole job from 12m44s to 2m02s. The `netronome` artifact is 315 MB in both runs, so the fast run builds the same seven targets.

| | cold ([33504162271](https://github.com/autobrr/netronome/actions/runs/33504162271)) | warm ([33507842736](https://github.com/autobrr/netronome/actions/runs/33507842736)) |
|---|---|---|
| Cache restore | miss, 0s | 29s (1854 MB) |
| `Run GoReleaser build` | 12m04s | 1m16s |
| Job total | 12m44s | 2m02s |
| `netronome` artifact | 315 MB | 315 MB |

## Why
`setup-go` keys its cache on `go.mod` and the Go version only, so the `test` job and the `goreleaserbuild` job collide on one key. The test job wins the race and stores a native linux/amd64 cache, which gives no hits for the seven cross-compile targets. GoReleaser then refuses to save its own cache:

```
Cache restored from key: setup-go-Linux-x64-ubuntu24-go-1.26.7-f1ff6898...
Post Set up Go: Cache hit occurred on the primary key setup-go-..., not saving cache.
```

So it compiled all seven targets from zero on every run. Measured cold, one target costs 3m47s of CPU and 1019 MB of build cache, over 839 packages. Seven targets is about 26 CPU-minutes on a 4-vCPU runner.

`setup-go` gives no way to add a prefix to its key, so a separate `actions/cache` step is the supported answer.

The build step also has to run on branch pushes for the cache to be any use. Both GoReleaser steps were skipped on a push to develop, so that job ran for 17 seconds and built nothing. Under the new key it would have stored an empty cache on the default branch, and because the primary key then hits, `actions/cache` would never replace it. Pull request runs cannot read each other's caches, so the default branch entry is the one that matters.

## Testing
- [ ] `pnpm -C web lint`
- [ ] `pnpm -C web build`
- [x] Other: workflow-only change, measured on this PR's own runs, numbers above. The first run seeded the cache and the second restored it. Cache behaviour on develop can only be confirmed after merge, because a pull request cannot write the default branch cache.

`--parallelism 7` was tried and dropped: 12m36s against 12m04s at the previous value of 5. Seven concurrent builds, each with `GOMAXPROCS` 4, oversubscribe a 4-vCPU runner by more than the idle tail wave costs.

## Screenshots (if UI)
- n/a

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [ ] AI-assisted changes reviewed and edited by a human