### PR TITLE
fix(monitor): stop the false temperature warning for NVMe spot sensors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,10 @@ jobs:
         working-directory: web
         run: pnpm tsc --noEmit
 
+      - name: Test frontend
+        working-directory: web
+        run: pnpm test
+
       - name: Fetch premium themes
         run: |
           if [ -n "${{ secrets.THEMES_REPO_TOKEN }}" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `make watch`: runs Go watcher only (prompts to install `air` if missing).
 - `make docker-build` / `make docker-run`: build and run a Docker image.
 - `pnpm -C web dev|build|lint`: frontend dev server, production build, lint.
+- `pnpm -C web test`: frontend unit tests (`node:test`, no test framework). CI runs this in the web job.
 - `go test ./...`: backend unit tests.
 - `./test/test-local.sh`: local dockerized scenario tests.
 
@@ -26,6 +27,7 @@
 
 ## Testing Guidelines
 - Go tests live alongside code as `*_test.go`.
+- Frontend tests live alongside code as `*.test.ts` and use `node:test`; do not add a test framework.
 - Prefer table-driven tests for new backend logic.
 - Scenario scripts live in `test/`; add fixtures under `test/data/`.
 - `test/` also contains docker-compose scenarios, SSL cert scripts, and base-URL test harnesses.

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "dev": "NETRONOME__BASE_URL=\"\" vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --experimental-strip-types --test \"src/**/*.test.ts\"",
     "preview": "vite preview",
     "unused": "knip",
     "unused:production": "knip --production",

--- a/web/src/components/monitor/MonitorHardwareStats.tsx
+++ b/web/src/components/monitor/MonitorHardwareStats.tsx
@@ -13,6 +13,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { HardwareStats } from "@/api/monitor";
 import { formatBytes } from "@/utils/formatBytes";
+import {
+  temperatureLevel,
+  temperatureLimits,
+} from "@/utils/temperature";
 
 interface MonitorHardwareStatsProps {
   hardwareStats: HardwareStats;
@@ -443,37 +447,17 @@ export const MonitorHardwareStats: React.FC<MonitorHardwareStatsProps> = ({
                         </h4>
                         <div className="grid grid-cols-2 gap-3">
                           {temps.map((temp, index) => {
-                            // For invalid critical temps (> 1000°C), use absolute temperature thresholds
-                            const hasValidCritical =
-                              temp.critical &&
-                              temp.critical > 0 &&
-                              temp.critical < 1000;
+                            // Fill the bar against the limit this sensor is
+                            // judged by, so the bar and the color agree.
+                            const percentage = Math.min(
+                              (temp.temperature / temperatureLimits(temp).hot) *
+                                100,
+                              100
+                            );
 
-                            const percentage =
-                              hasValidCritical && temp.critical
-                                ? Math.min(
-                                    (temp.temperature / temp.critical) * 100,
-                                    100
-                                  )
-                                : (temp.temperature / 100) * 100; // Assume 100°C max if no valid critical temp
-
-                            // Use different thresholds based on sensor type
-                            // For HDDs/SSDs, 50°C is warm, 60°C is hot
-                            // For CPUs/NVMe, 60°C is warm, 80°C is hot
-                            const isStorageSensor =
-                              temp.sensor_key
-                                .toLowerCase()
-                                .includes("smart_") ||
-                              temp.label?.toLowerCase().includes("hdd") ||
-                              temp.label?.toLowerCase().includes("ssd");
-
-                            const warmThreshold = isStorageSensor ? 50 : 60;
-                            const hotThreshold = isStorageSensor ? 60 : 80;
-
-                            const isWarm =
-                              temp.temperature > warmThreshold &&
-                              temp.temperature <= hotThreshold;
-                            const isHot = temp.temperature > hotThreshold;
+                            const level = temperatureLevel(temp);
+                            const isWarm = level === "warm";
+                            const isHot = level === "hot";
 
                             const getTemperatureColor = () => {
                               if (isHot) return "var(--color-red-500, #ef4444)";

--- a/web/src/components/monitor/MonitorUsageModal.tsx
+++ b/web/src/components/monitor/MonitorUsageModal.tsx
@@ -16,6 +16,7 @@ import { getAgentIcon } from "@/utils/agentIcons";
 import { useMonitorAgent } from "@/hooks/useMonitorAgent";
 import { parseMonitorUsagePeriods } from "@/utils/monitorDataParser";
 import { formatBytes } from "@/utils/formatBytes";
+import { temperatureLevel } from "@/utils/temperature";
 import { TailscaleLogo } from "@/components/icons/TailscaleLogo";
 import {
   Dialog,
@@ -215,10 +216,10 @@ export const MonitorUsageModal: React.FC<MonitorUsageModalProps> = ({
                         hardwareStats.temperature.length > 0 &&
                         (() => {
                           const hotSensors = hardwareStats.temperature.filter(
-                            (t) => t.temperature > 80,
+                            (t) => temperatureLevel(t) === "hot",
                           );
                           const warmSensors = hardwareStats.temperature.filter(
-                            (t) => t.temperature > 60 && t.temperature <= 80,
+                            (t) => temperatureLevel(t) === "warm",
                           );
 
                           if (hotSensors.length > 0) {

--- a/web/src/components/monitor/tabs/MonitorOverviewTab.tsx
+++ b/web/src/components/monitor/tabs/MonitorOverviewTab.tsx
@@ -19,9 +19,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLinux, faApple } from "@fortawesome/free-brands-svg-icons";
-import { MonitorAgent, MonitorStatus } from "@/api/monitor";
+import { MonitorAgent, MonitorStatus, TemperatureStats } from "@/api/monitor";
 import { useMonitorAgent } from "@/hooks/useMonitorAgent";
 import { formatBytes } from "@/utils/formatBytes";
+import { temperatureLevel } from "@/utils/temperature";
 import { parseMonitorUsagePeriods } from "@/utils/monitorDataParser";
 import { MonitorOfflineBanner } from "../MonitorOfflineBanner";
 
@@ -200,18 +201,14 @@ const ResourceProgressBar: React.FC<ResourceProgressBarProps> = ({
 
 // Temperature alert component
 interface TemperatureAlertProps {
-  temperatures?: Array<{
-    sensor_key: string;
-    label?: string;
-    temperature: number;
-  }>;
+  temperatures?: TemperatureStats[];
 }
 
 const TemperatureAlert: React.FC<TemperatureAlertProps> = ({ temperatures }) => {
   if (!temperatures || temperatures.length === 0) return null;
 
-  const hotSensors = temperatures.filter((t) => t.temperature > 80);
-  const warmSensors = temperatures.filter((t) => t.temperature > 60 && t.temperature <= 80);
+  const hotSensors = temperatures.filter((t) => temperatureLevel(t) === "hot");
+  const warmSensors = temperatures.filter((t) => temperatureLevel(t) === "warm");
 
   if (hotSensors.length === 0 && warmSensors.length === 0) return null;
 
@@ -253,7 +250,7 @@ const TemperatureAlert: React.FC<TemperatureAlertProps> = ({ temperatures }) => 
               <span
                 key={`${sensor.sensor_key}-${idx}`}
                 className={`text-xs sm:text-sm ${
-                  sensor.temperature > 80
+                  temperatureLevel(sensor) === "hot"
                     ? "text-red-700 dark:text-red-300"
                     : "text-amber-700 dark:text-amber-300"
                 }`}

--- a/web/src/utils/temperature.test.ts
+++ b/web/src/utils/temperature.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { TemperatureStats } from "../api/monitor.ts";
+import { temperatureLevel } from "./temperature.ts";
+
+// Readings from a healthy Proxmox host. smartctl reported zero seconds above
+// the warning threshold for both NVMe drives at these values.
+const healthy: TemperatureStats[] = [
+  { sensor_key: "acpitz", temperature: 27.8 },
+  { sensor_key: "r8169_0_400:00", temperature: 39.5, critical: 120 },
+  { sensor_key: "nvme_composite", temperature: 39.85, critical: 83.85 },
+  { sensor_key: "nvme_sensor_2", temperature: 61.85 },
+  { sensor_key: "nvme_composite", temperature: 41.85, critical: 74.85 },
+  { sensor_key: "nvme_sensor_1", temperature: 76.8, critical: 65261.85 },
+  { sensor_key: "nvme_sensor_2", temperature: 72.85, critical: 65261.85 },
+  { sensor_key: "coretemp_package_id_0", temperature: 35, critical: 80 },
+  { sensor_key: "nct6687_system", temperature: 38, critical: 39 },
+  { sensor_key: "nct6687_m2_1", temperature: 32, critical: 32 },
+];
+
+test("a healthy host raises no temperature alert", () => {
+  for (const sensor of healthy) {
+    assert.equal(
+      temperatureLevel(sensor),
+      "normal",
+      `${sensor.sensor_key} at ${sensor.temperature}C`
+    );
+  }
+});
+
+test("hot sensors still alert", () => {
+  const cases: Array<[TemperatureStats, string]> = [
+    // Above the drive's own composite warning threshold.
+    [{ sensor_key: "nvme_composite", temperature: 78, critical: 74.85 }, "hot"],
+    [{ sensor_key: "nvme_sensor_1", temperature: 96, critical: 65261.85 }, "hot"],
+    [{ sensor_key: "coretemp_core_0", temperature: 92, critical: 80 }, "hot"],
+    [{ sensor_key: "smart_sda", label: "WDC (SDA)", temperature: 55 }, "warm"],
+  ];
+
+  for (const [sensor, want] of cases) {
+    assert.equal(temperatureLevel(sensor), want, sensor.sensor_key);
+  }
+});

--- a/web/src/utils/temperature.ts
+++ b/web/src/utils/temperature.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { TemperatureStats } from "@/api/monitor";
+
+type TemperatureLevel = "normal" | "warm" | "hot";
+
+const SMART_LIMITS = { warm: 50, hot: 60 };
+// NVMe temperature sensors 1-8 are vendor spot sensors on the controller die
+// and the NAND. The drive applies its warning and critical limits to the
+// composite value only, and a spot sensor 20-30 C above the composite is
+// normal.
+const NVME_SPOT_LIMITS = { warm: 85, hot: 95 };
+const DEFAULT_LIMITS = { warm: 60, hot: 80 };
+
+const isSmartSensor = (sensor: TemperatureStats): boolean => {
+  const key = sensor.sensor_key.toLowerCase();
+  const label = (sensor.label || "").toLowerCase();
+  return (
+    key.includes("smart_") || label.includes("hdd") || label.includes("ssd")
+  );
+};
+
+// Some sensors report a useless limit: NVMe spot sensors report 65261.85 C,
+// and board sensors report a limit that tracks the current reading.
+const reportedLimit = (sensor: TemperatureStats): number | null =>
+  sensor.critical && sensor.critical > 0 && sensor.critical < 1000
+    ? sensor.critical
+    : null;
+
+export function temperatureLimits(sensor: TemperatureStats): {
+  warm: number;
+  hot: number;
+} {
+  const key = sensor.sensor_key.toLowerCase();
+
+  if (isSmartSensor(sensor)) return SMART_LIMITS;
+  if (key.startsWith("nvme") && key.includes("_sensor_"))
+    return NVME_SPOT_LIMITS;
+
+  if (key.startsWith("nvme") && key.endsWith("_composite")) {
+    // The composite limit is the drive's own warning threshold, and it can
+    // sit below the default limits.
+    const limit = reportedLimit(sensor);
+    if (limit !== null) return { warm: limit - 10, hot: limit };
+  }
+
+  return DEFAULT_LIMITS;
+}
+
+export function temperatureLevel(sensor: TemperatureStats): TemperatureLevel {
+  const limits = temperatureLimits(sensor);
+  if (sensor.temperature > limits.hot) return "hot";
+  if (sensor.temperature > limits.warm) return "warm";
+  return "normal";
+}


### PR DESCRIPTION
## Summary
- Give NVMe spot sensors their own temperature limits, so a healthy drive no longer shows a "Temperature Warning".

## Why
- The dashboard applied flat 60 C / 80 C limits to every sensor. NVMe temperature sensors 1-8 are vendor spot sensors on the controller die and the NAND, and they run 20-30 C above the composite value by design. The drive applies its warning and critical limits to the composite value only.
- A limit-relative rule alone does not work, because the reported limits are frequently wrong: NVMe spot sensors report 65261.85 C, and board sensors (nct6687) report a limit that tracks the current reading.
- The three components that colored temperatures each had their own copy of the limits. They now share one module, which also gets the composite reading checked against the limit the drive reports.

## Testing
- [x] `pnpm -C web build`
- [x] Other: new `pnpm -C web test` (`node:test`, no new dependencies), added to the web CI job.
- Ran the classifier over the live payload from `GET /system/hardware` on a Proxmox host with two NVMe drives. Before: three sensors alerted (76.8 C and 72.9 C on drive 1, 61.9 C on drive 2). After: 0 alerts of 22 sensors. `smartctl` reports `Warning Comp. Temperature Time: 0` for both drives, so the drives never saw a warning either.

## Screenshots (if UI)
- None. The change removes an alert banner and adjusts sensor bar colors.

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [ ] AI-assisted changes reviewed and edited by a human

## Note
The backend notification path (`internal/monitor/client.go`) still picks the hottest raw sensor, so an NVMe spot sensor can trip a user-configured temperature rule. That path is opt-in and is not changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent temperature classification across hardware monitoring views.
  * Temperature limits now adapt to sensor type and reported thresholds.
  * Added automated coverage for normal, warm, and hot sensor readings.

* **Bug Fixes**
  * Improved temperature progress bars, alert colors, and sensor status indicators.

* **Tests**
  * Added frontend test execution to the release validation workflow.
  * Documented frontend testing commands and conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->