### PR TITLE
fix(monitor): give agent proxy requests a timeout and a context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,12 @@ agent as the server stores it, not a monitor in the packet loss sense.
 **Bandwidth** — the interface counters that an agent reads with `vnstat`. This is
 the traffic that the machine passes. It is not a speed test.
 
+**Agent client** — the module in `internal/monitor` through which the server
+fetches from the HTTP endpoints of an agent. It owns the base URL rule, the API
+key header, the shared HTTP client, and the timeouts. The proxy handlers are its
+callers, and the poller becomes a caller later. The live-data SSE stream is not
+part of it.
+
 **DNS monitor** (`DNSMonitor`) — a resolver, an interval, a query, and a protocol
 (UDP, TCP, or DoT). The server sends the query to the resolver and records the
 response time and the response code. A check fails on a timeout or an error

--- a/internal/handlers/monitor.go
+++ b/internal/handlers/monitor.go
@@ -5,8 +5,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -109,13 +109,7 @@ func (h *MonitorHandler) CreateAgent(c *gin.Context) {
 	}
 
 	// Ensure URL has the correct SSE endpoint
-	if !strings.HasSuffix(agent.URL, "/events?stream=live-data") {
-		if strings.HasSuffix(agent.URL, "/") {
-			agent.URL = agent.URL + "events?stream=live-data"
-		} else {
-			agent.URL = agent.URL + "/events?stream=live-data"
-		}
-	}
+	agent.URL = monitor.AgentStreamURL(agent.URL)
 
 	// Auto-detect Tailscale agents based on URL (if not already set by discovery)
 	if !agent.IsTailscale && utils.IsTailscaleURL(agent.URL) {
@@ -216,13 +210,7 @@ func (h *MonitorHandler) UpdateAgent(c *gin.Context) {
 	}
 
 	// Ensure URL has the correct SSE endpoint
-	if !strings.HasSuffix(agent.URL, "/events?stream=live-data") {
-		if strings.HasSuffix(agent.URL, "/") {
-			agent.URL = agent.URL + "events?stream=live-data"
-		} else {
-			agent.URL = agent.URL + "/events?stream=live-data"
-		}
-	}
+	agent.URL = monitor.AgentStreamURL(agent.URL)
 
 	// Update agent in database
 	if err := h.db.UpdateMonitorAgent(c.Request.Context(), &agent); err != nil {
@@ -330,6 +318,19 @@ func (h *MonitorHandler) StopAgent(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Agent stopped successfully"})
 }
 
+// respondAgentStatus answers the caller when an agent request failed because
+// the agent returned an error status. It returns true when it wrote a response.
+func respondAgentStatus(c *gin.Context, err error) bool {
+	var statusErr *monitor.StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+
+	log.Error().Int("status", statusErr.StatusCode).Str("url", statusErr.URL).Msg("Agent returned error status")
+	c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Agent returned status %d", statusErr.StatusCode)})
+	return true
+}
+
 // GetAgentNativeVnstat returns the native bandwidth monitor JSON output from an agent for validation
 func (h *MonitorHandler) GetAgentNativeVnstat(c *gin.Context) {
 	idStr := c.Param("id")
@@ -351,34 +352,13 @@ func (h *MonitorHandler) GetAgentNativeVnstat(c *gin.Context) {
 		return
 	}
 
-	// Build the historical export URL from the agent's base URL
-	baseURL := strings.TrimSuffix(agent.URL, "/events?stream=live-data")
-	exportURL := baseURL + "/export/historical"
-
-	// Get the interface parameter if provided
-	iface := c.Query("interface")
-	if iface != "" {
-		exportURL += "?interface=" + iface
-	}
-
-	// Create HTTP request with API key if configured
-	req, err := http.NewRequest("GET", exportURL, nil)
+	body, err := monitor.NewAgentClient(agent).Historical(c.Request.Context(), c.Query("interface"))
 	if err != nil {
-		log.Error().Err(err).Str("url", exportURL).Msg("Failed to create request")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create request"})
-		return
-	}
+		if respondAgentStatus(c, err) {
+			return
+		}
 
-	// Add API key if configured
-	if agent.APIKey != nil && *agent.APIKey != "" {
-		req.Header.Set("X-API-Key", *agent.APIKey)
-	}
-
-	// Make HTTP request to agent's export endpoint
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error().Err(err).Str("url", exportURL).Msg("Failed to fetch native bandwidth data from agent, falling back to cached data")
+		log.Error().Err(err).Int64("agent_id", id).Str("url", agent.URL).Msg("Failed to fetch native bandwidth data from agent, falling back to cached data")
 
 		// Fall back to cached historical snapshots from database
 		// We need to reconstruct the vnstat JSON from individual period snapshots
@@ -521,21 +501,6 @@ func (h *MonitorHandler) GetAgentNativeVnstat(c *gin.Context) {
 		c.JSON(http.StatusOK, response)
 		return
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error().Int("status", resp.StatusCode).Str("url", exportURL).Msg("Agent returned error status")
-		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Agent returned status %d", resp.StatusCode)})
-		return
-	}
-
-	// Read and parse the JSON response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to read response body")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read response"})
-		return
-	}
 
 	// Validate JSON
 	var bandwidthData interface{}
@@ -571,28 +536,15 @@ func (h *MonitorHandler) GetAgentSystemInfo(c *gin.Context) {
 		return
 	}
 
-	// Build the system info URL from the agent's base URL
-	baseURL := strings.TrimSuffix(agent.URL, "/events?stream=live-data")
-	systemURL := baseURL + "/system/info"
+	agentClient := monitor.NewAgentClient(agent)
 
-	// Create HTTP request with API key if configured
-	req, err := http.NewRequest("GET", systemURL, nil)
+	body, err := agentClient.SystemInfo(c.Request.Context())
 	if err != nil {
-		log.Error().Err(err).Str("url", systemURL).Msg("Failed to create request")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create request"})
-		return
-	}
+		if respondAgentStatus(c, err) {
+			return
+		}
 
-	// Add API key if configured
-	if agent.APIKey != nil && *agent.APIKey != "" {
-		req.Header.Set("X-API-Key", *agent.APIKey)
-	}
-
-	// Make HTTP request to agent's system endpoint
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error().Err(err).Str("url", systemURL).Msg("Failed to fetch system info from agent, falling back to cached data")
+		log.Error().Err(err).Int64("agent_id", id).Str("url", agent.URL).Msg("Failed to fetch system info from agent, falling back to cached data")
 
 		// Fall back to cached system info from database
 		systemInfo, dbErr := h.db.GetMonitorSystemInfo(c.Request.Context(), id)
@@ -641,21 +593,6 @@ func (h *MonitorHandler) GetAgentSystemInfo(c *gin.Context) {
 		c.JSON(http.StatusOK, response)
 		return
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error().Int("status", resp.StatusCode).Str("url", systemURL).Msg("Agent returned error status")
-		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Agent returned status %d", resp.StatusCode)})
-		return
-	}
-
-	// Read and parse the JSON response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to read response body")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read response"})
-		return
-	}
 
 	// Parse the system data to add agent version
 	var systemData map[string]interface{}
@@ -665,22 +602,10 @@ func (h *MonitorHandler) GetAgentSystemInfo(c *gin.Context) {
 		return
 	}
 
-	// Fetch agent version from /netronome/info endpoint  
-	agentBaseURL := strings.TrimSuffix(agent.URL, "/events?stream=live-data")
-	infoURL := agentBaseURL + "/netronome/info"
-	infoReq, infoErr := http.NewRequestWithContext(c.Request.Context(), "GET", infoURL, nil)
-	if infoErr == nil {
-		infoClient := &http.Client{Timeout: 5 * time.Second}
-		infoResp, infoRespErr := infoClient.Do(infoReq)
-		if infoRespErr == nil && infoResp.StatusCode == http.StatusOK {
-			defer infoResp.Body.Close()
-			var agentInfo struct {
-				Version string `json:"version"`
-			}
-			if decodeErr := json.NewDecoder(infoResp.Body).Decode(&agentInfo); decodeErr == nil && agentInfo.Version != "" {
-				systemData["agent_version"] = agentInfo.Version
-			}
-		}
+	// The agent version is an addition to the response. A failure here is not
+	// an error for the caller.
+	if info, infoErr := agentClient.Info(c.Request.Context()); infoErr == nil && info.Version != "" {
+		systemData["agent_version"] = info.Version
 	}
 
 	// Return the augmented system info
@@ -708,28 +633,13 @@ func (h *MonitorHandler) GetAgentHardwareStats(c *gin.Context) {
 		return
 	}
 
-	// Build the hardware stats URL from the agent's base URL
-	baseURL := strings.TrimSuffix(agent.URL, "/events?stream=live-data")
-	hardwareURL := baseURL + "/system/hardware"
-
-	// Create HTTP request with API key if configured
-	req, err := http.NewRequest("GET", hardwareURL, nil)
+	body, err := monitor.NewAgentClient(agent).HardwareStats(c.Request.Context())
 	if err != nil {
-		log.Error().Err(err).Str("url", hardwareURL).Msg("Failed to create request")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create request"})
-		return
-	}
+		if respondAgentStatus(c, err) {
+			return
+		}
 
-	// Add API key if configured
-	if agent.APIKey != nil && *agent.APIKey != "" {
-		req.Header.Set("X-API-Key", *agent.APIKey)
-	}
-
-	// Make HTTP request to agent's hardware endpoint
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error().Err(err).Str("url", hardwareURL).Msg("Failed to fetch hardware stats from agent, falling back to cached data")
+		log.Error().Err(err).Int64("agent_id", id).Str("url", agent.URL).Msg("Failed to fetch hardware stats from agent, falling back to cached data")
 
 		// Fall back to cached resource stats from database
 		// Try to get the most recent resource stats (last 24 hours)
@@ -836,21 +746,6 @@ func (h *MonitorHandler) GetAgentHardwareStats(c *gin.Context) {
 		c.JSON(http.StatusOK, response)
 		return
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error().Int("status", resp.StatusCode).Str("url", hardwareURL).Msg("Agent returned error status")
-		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Agent returned status %d", resp.StatusCode)})
-		return
-	}
-
-	// Read and parse the JSON response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to read response body")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read response"})
-		return
-	}
 
 	// Validate JSON
 	var hardwareData interface{}
@@ -886,44 +781,14 @@ func (h *MonitorHandler) GetAgentPeakStats(c *gin.Context) {
 		return
 	}
 
-	// Build the peak stats URL from the agent's base URL
-	baseURL := strings.TrimSuffix(agent.URL, "/events?stream=live-data")
-	peaksURL := baseURL + "/stats/peaks"
-
-	// Create HTTP request with API key if configured
-	req, err := http.NewRequest("GET", peaksURL, nil)
+	body, err := monitor.NewAgentClient(agent).PeakStats(c.Request.Context())
 	if err != nil {
-		log.Error().Err(err).Str("url", peaksURL).Msg("Failed to create request")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create request"})
-		return
-	}
+		if respondAgentStatus(c, err) {
+			return
+		}
 
-	// Add API key if configured
-	if agent.APIKey != nil && *agent.APIKey != "" {
-		req.Header.Set("X-API-Key", *agent.APIKey)
-	}
-
-	// Make HTTP request to agent's peaks endpoint
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error().Err(err).Str("url", peaksURL).Msg("Failed to fetch peak stats")
+		log.Error().Err(err).Int64("agent_id", id).Str("url", agent.URL).Msg("Failed to fetch peak stats")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch peak stats"})
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error().Int("status", resp.StatusCode).Str("url", peaksURL).Msg("Agent returned error status")
-		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Agent returned status %d", resp.StatusCode)})
-		return
-	}
-
-	// Read and parse the JSON response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to read response body")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read response"})
 		return
 	}
 

--- a/internal/monitor/agent_client.go
+++ b/internal/monitor/agent_client.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+// agentStreamSuffix is the SSE path that an agent URL carries in the database.
+const agentStreamSuffix = "/events?stream=live-data"
+
+// Timeout ceilings per endpoint. The historical export reads the full vnstat
+// database, so it gets more time. The info endpoint is a best-effort version
+// lookup on the path of a browser request, so it gets less.
+const (
+	agentTimeout       = 30 * time.Second
+	agentExportTimeout = 60 * time.Second
+	agentInfoTimeout   = 5 * time.Second
+)
+
+// AgentBaseURL returns the root URL of an agent from the URL that the database
+// stores, which ends with the SSE stream path.
+func AgentBaseURL(agentURL string) string {
+	return strings.TrimRight(strings.TrimSuffix(agentURL, agentStreamSuffix), "/")
+}
+
+// AgentStreamURL returns the agent URL with the SSE stream path attached.
+func AgentStreamURL(agentURL string) string {
+	if strings.HasSuffix(agentURL, agentStreamSuffix) {
+		return agentURL
+	}
+	return strings.TrimRight(agentURL, "/") + agentStreamSuffix
+}
+
+// Readable arguments for the auth parameter of get.
+const (
+	withAPIKey = true
+	noAPIKey   = false
+)
+
+// setAgentAuth adds the API key header to a request when the agent has a key.
+func setAgentAuth(req *http.Request, apiKey *string) {
+	if apiKey != nil && *apiKey != "" {
+		req.Header.Set("X-API-Key", *apiKey)
+	}
+}
+
+// AgentClient fetches from the HTTP endpoints of one agent.
+type AgentClient struct {
+	baseURL string
+	apiKey  *string
+	http    *http.Client
+}
+
+// NewAgentClient returns a client for the given agent.
+func NewAgentClient(agent *types.MonitorAgent) *AgentClient {
+	return &AgentClient{
+		baseURL: AgentBaseURL(agent.URL),
+		apiKey:  agent.APIKey,
+		// http.DefaultClient has no timeout of its own, which is correct
+		// here: each method sets its own ceiling on the request context, so
+		// cancellation by the caller keeps working.
+		http: http.DefaultClient,
+	}
+}
+
+// AgentInfo is the response of the public agent info endpoint.
+type AgentInfo struct {
+	Version string `json:"version"`
+}
+
+// SystemInfo returns the raw response of the agent system info endpoint.
+func (c *AgentClient) SystemInfo(ctx context.Context) ([]byte, error) {
+	return c.get(ctx, "/system/info", agentTimeout, withAPIKey)
+}
+
+// HardwareStats returns the raw response of the agent hardware endpoint.
+func (c *AgentClient) HardwareStats(ctx context.Context) ([]byte, error) {
+	return c.get(ctx, "/system/hardware", agentTimeout, withAPIKey)
+}
+
+// PeakStats returns the raw response of the agent peak statistics endpoint.
+func (c *AgentClient) PeakStats(ctx context.Context) ([]byte, error) {
+	return c.get(ctx, "/stats/peaks", agentTimeout, withAPIKey)
+}
+
+// Historical returns the raw vnstat export of the agent. An empty interface
+// name asks the agent for its default interface.
+func (c *AgentClient) Historical(ctx context.Context, iface string) ([]byte, error) {
+	path := "/export/historical"
+	if iface != "" {
+		path += "?interface=" + url.QueryEscape(iface)
+	}
+	return c.get(ctx, path, agentExportTimeout, withAPIKey)
+}
+
+// Info returns the version of the agent. The endpoint is public, so the
+// request sends no API key.
+func (c *AgentClient) Info(ctx context.Context) (AgentInfo, error) {
+	body, err := c.get(ctx, "/netronome/info", agentInfoTimeout, noAPIKey)
+	if err != nil {
+		return AgentInfo{}, err
+	}
+
+	var info AgentInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return AgentInfo{}, fmt.Errorf("decode agent info: %w", err)
+	}
+	return info, nil
+}
+
+// get sends one GET request to the agent and reads the full body. The timeout
+// is a ceiling on top of the context of the caller, so cancellation by the
+// caller still ends the request early.
+func (c *AgentClient) get(ctx context.Context, path string, timeout time.Duration, auth bool) ([]byte, error) {
+	requestURL := c.baseURL + path
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request for %s: %w", path, err)
+	}
+	if auth {
+		setAgentAuth(req, c.apiKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{StatusCode: resp.StatusCode, URL: requestURL}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return body, nil
+}

--- a/internal/monitor/agent_client_test.go
+++ b/internal/monitor/agent_client_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/autobrr/netronome/internal/types"
+)
+
+func TestAgentBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"stream suffix", "http://host:8200/events?stream=live-data", "http://host:8200"},
+		{"trailing slash", "http://host:8200/", "http://host:8200"},
+		{"bare", "http://host:8200", "http://host:8200"},
+		{"base path", "http://host:8200/agent/events?stream=live-data", "http://host:8200/agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AgentBaseURL(tt.in); got != tt.want {
+				t.Errorf("AgentBaseURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentStreamURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already suffixed", "http://host:8200/events?stream=live-data", "http://host:8200/events?stream=live-data"},
+		{"trailing slash", "http://host:8200/", "http://host:8200/events?stream=live-data"},
+		{"bare", "http://host:8200", "http://host:8200/events?stream=live-data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AgentStreamURL(tt.in); got != tt.want {
+				t.Errorf("AgentStreamURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeAgent starts an httptest server that records the path and API key of the
+// last request it received.
+type fakeAgent struct {
+	server *httptest.Server
+	path   string
+	apiKey string
+}
+
+func newFakeAgent(t *testing.T, body string) *fakeAgent {
+	t.Helper()
+
+	fa := &fakeAgent{}
+	fa.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fa.path = r.URL.RequestURI()
+		fa.apiKey = r.Header.Get("X-API-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(fa.server.Close)
+	return fa
+}
+
+func (fa *fakeAgent) client(apiKey *string) *AgentClient {
+	return NewAgentClient(&types.MonitorAgent{URL: fa.server.URL + "/events?stream=live-data", APIKey: apiKey})
+}
+
+func TestAgentClientEndpoints(t *testing.T) {
+	key := "secret"
+	empty := ""
+
+	tests := []struct {
+		name     string
+		apiKey   *string
+		call     func(*AgentClient) error
+		wantPath string
+		wantKey  string
+	}{
+		{
+			name:     "system info",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.SystemInfo(context.Background()); return err },
+			wantPath: "/system/info",
+			wantKey:  key,
+		},
+		{
+			name:     "hardware stats",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.HardwareStats(context.Background()); return err },
+			wantPath: "/system/hardware",
+			wantKey:  key,
+		},
+		{
+			name:     "peak stats",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.PeakStats(context.Background()); return err },
+			wantPath: "/stats/peaks",
+			wantKey:  key,
+		},
+		{
+			name:     "historical without interface",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.Historical(context.Background(), ""); return err },
+			wantPath: "/export/historical",
+			wantKey:  key,
+		},
+		{
+			name:     "historical with interface",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.Historical(context.Background(), "eth 0"); return err },
+			wantPath: "/export/historical?interface=eth+0",
+			wantKey:  key,
+		},
+		{
+			// The agent info endpoint is public, so the API key must not be sent.
+			name:     "info sends no api key",
+			apiKey:   &key,
+			call:     func(c *AgentClient) error { _, err := c.Info(context.Background()); return err },
+			wantPath: "/netronome/info",
+			wantKey:  "",
+		},
+		{
+			name:     "no api key configured",
+			apiKey:   nil,
+			call:     func(c *AgentClient) error { _, err := c.SystemInfo(context.Background()); return err },
+			wantPath: "/system/info",
+			wantKey:  "",
+		},
+		{
+			name:     "empty api key configured",
+			apiKey:   &empty,
+			call:     func(c *AgentClient) error { _, err := c.SystemInfo(context.Background()); return err },
+			wantPath: "/system/info",
+			wantKey:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fa := newFakeAgent(t, `{"version":"1.2.3"}`)
+			if err := tt.call(fa.client(tt.apiKey)); err != nil {
+				t.Fatalf("call failed: %v", err)
+			}
+			if fa.path != tt.wantPath {
+				t.Errorf("path = %q, want %q", fa.path, tt.wantPath)
+			}
+			if fa.apiKey != tt.wantKey {
+				t.Errorf("X-API-Key = %q, want %q", fa.apiKey, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestAgentClientInfoDecodes(t *testing.T) {
+	fa := newFakeAgent(t, `{"version":"1.2.3"}`)
+
+	info, err := fa.client(nil).Info(context.Background())
+	if err != nil {
+		t.Fatalf("Info failed: %v", err)
+	}
+	if info.Version != "1.2.3" {
+		t.Errorf("version = %q, want %q", info.Version, "1.2.3")
+	}
+}
+
+// trackingBody reports whether the response body was closed.
+type trackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestAgentClientClosesBodyOnErrorStatus(t *testing.T) {
+	body := &trackingBody{Reader: strings.NewReader("nope")}
+	client := NewAgentClient(&types.MonitorAgent{URL: "http://agent.invalid"})
+	client.http = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: body, Request: r}, nil
+	})}
+
+	_, err := client.SystemInfo(context.Background())
+
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("err = %v, want *StatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", statusErr.StatusCode, http.StatusInternalServerError)
+	}
+	if !body.closed {
+		t.Error("response body was not closed")
+	}
+}
+
+// blockedServer returns an agent that answers no request until the test ends.
+func blockedServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	blocked := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	t.Cleanup(func() {
+		close(blocked)
+		server.Close()
+	})
+	return server
+}
+
+func TestAgentClientTimeoutCeiling(t *testing.T) {
+	client := NewAgentClient(&types.MonitorAgent{URL: blockedServer(t).URL})
+
+	// The caller passes a context with no deadline; the ceiling must still end the request.
+	start := time.Now()
+	_, err := client.get(context.Background(), "/system/info", 50*time.Millisecond, withAPIKey)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("request took %v, ceiling did not apply", elapsed)
+	}
+}
+
+func TestAgentClientCallerCancellation(t *testing.T) {
+	client := NewAgentClient(&types.MonitorAgent{URL: blockedServer(t).URL})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	_, err := client.SystemInfo(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}

--- a/internal/monitor/agent_client_test.go
+++ b/internal/monitor/agent_client_test.go
@@ -222,7 +222,7 @@ func blockedServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	blocked := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		<-blocked
 	}))
 	t.Cleanup(func() {

--- a/internal/monitor/capabilities.go
+++ b/internal/monitor/capabilities.go
@@ -29,12 +29,14 @@ type agentCapabilities struct {
 	hardwareStats endpointSupport
 }
 
-type httpStatusError struct {
+// StatusError is the error that an agent request returns when the agent
+// answers with a status code other than 200.
+type StatusError struct {
 	StatusCode int
 	URL        string
 }
 
-func (e *httpStatusError) Error() string {
+func (e *StatusError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
@@ -57,7 +59,7 @@ func detectAgentCapabilities(ctx context.Context, baseURL string) (agentCapabili
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return agentCapabilities{}, &httpStatusError{StatusCode: resp.StatusCode, URL: rootURL}
+		return agentCapabilities{}, &StatusError{StatusCode: resp.StatusCode, URL: rootURL}
 	}
 
 	var root struct {

--- a/internal/monitor/capabilities_test.go
+++ b/internal/monitor/capabilities_test.go
@@ -74,7 +74,7 @@ func TestClient_HandleEndpointNotFound_DisablesPolling(t *testing.T) {
 		t.Fatalf("expected system info polling enabled by default")
 	}
 
-	if !c.handleEndpointNotFound(&httpStatusError{StatusCode: http.StatusNotFound, URL: "http://x/system/info"}, endpointSystemInfo) {
+	if !c.handleEndpointNotFound(&StatusError{StatusCode: http.StatusNotFound, URL: "http://x/system/info"}, endpointSystemInfo) {
 		t.Fatalf("expected handleEndpointNotFound=true")
 	}
 	if c.shouldPollSystemInfo() {

--- a/internal/monitor/client.go
+++ b/internal/monitor/client.go
@@ -352,7 +352,7 @@ func (c *Client) IsConnected() (bool, *types.MonitorLiveData) {
 }
 
 func (c *Client) baseURL() string {
-	return strings.TrimSuffix(c.agent.URL, "/events?stream=live-data")
+	return AgentBaseURL(c.agent.URL)
 }
 
 func (c *Client) ensureCapabilities() {
@@ -392,7 +392,7 @@ func (c *Client) shouldPollHardwareStats() bool {
 }
 
 func (c *Client) handleEndpointNotFound(err error, ep agentEndpoint) bool {
-	var statusErr *httpStatusError
+	var statusErr *StatusError
 	if !errors.As(err, &statusErr) {
 		return false
 	}
@@ -498,10 +498,7 @@ func (c *Client) connectAndStream() error {
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	// Add API key if configured
-	if c.agent.APIKey != nil && *c.agent.APIKey != "" {
-		req.Header.Set("X-API-Key", *c.agent.APIKey)
-	}
+	setAgentAuth(req, c.agent.APIKey)
 
 	// Create HTTP client with timeout
 	client := &http.Client{
@@ -777,7 +774,7 @@ func (s *Service) fetchAndStoreResourceStats(client *Client) {
 
 // fetchSystemInfo fetches and stores system information from an agent
 func (s *Service) fetchSystemInfo(client *Client) error {
-	systemURL := strings.TrimRight(client.baseURL(), "/") + "/system/info"
+	systemURL := client.baseURL() + "/system/info"
 
 	req, err := http.NewRequestWithContext(client.ctx, "GET", systemURL, nil)
 	if err != nil {
@@ -796,7 +793,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return &httpStatusError{StatusCode: resp.StatusCode, URL: systemURL}
+		return &StatusError{StatusCode: resp.StatusCode, URL: systemURL}
 	}
 
 	// Read the response body first for debugging
@@ -826,18 +823,20 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 
 	// Fetch agent version from /netronome/info endpoint
 	agentVersion := ""
-	infoURL := strings.TrimRight(client.baseURL(), "/") + "/netronome/info"
+	infoURL := client.baseURL() + "/netronome/info"
 	infoReq, err := http.NewRequestWithContext(client.ctx, "GET", infoURL, nil)
 	if err == nil {
 		// Don't add API key for this endpoint as it's public
 		infoResp, err := httpClient.Do(infoReq)
-		if err == nil && infoResp.StatusCode == http.StatusOK {
+		if err == nil {
 			defer infoResp.Body.Close()
-			var agentInfo struct {
-				Version string `json:"version"`
-			}
-			if err := json.NewDecoder(infoResp.Body).Decode(&agentInfo); err == nil {
-				agentVersion = agentInfo.Version
+			if infoResp.StatusCode == http.StatusOK {
+				var agentInfo struct {
+					Version string `json:"version"`
+				}
+				if err := json.NewDecoder(infoResp.Body).Decode(&agentInfo); err == nil {
+					agentVersion = agentInfo.Version
+				}
 			}
 		}
 	}
@@ -897,7 +896,7 @@ func (s *Service) fetchSystemInfo(client *Client) error {
 
 // fetchHardwareStats fetches and stores hardware statistics from an agent
 func (s *Service) fetchHardwareStats(client *Client) error {
-	hardwareURL := strings.TrimRight(client.baseURL(), "/") + "/system/hardware"
+	hardwareURL := client.baseURL() + "/system/hardware"
 
 	req, err := http.NewRequestWithContext(client.ctx, "GET", hardwareURL, nil)
 	if err != nil {
@@ -916,7 +915,7 @@ func (s *Service) fetchHardwareStats(client *Client) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return &httpStatusError{StatusCode: resp.StatusCode, URL: hardwareURL}
+		return &StatusError{StatusCode: resp.StatusCode, URL: hardwareURL}
 	}
 
 	var hardwareStats struct {
@@ -1130,8 +1129,7 @@ func (s *Service) collectHistoricalSnapshots() {
 
 // fetchAndStoreHistoricalData fetches and stores vnstat historical data from an agent
 func (s *Service) fetchAndStoreHistoricalData(client *Client) {
-	baseURL := strings.TrimSuffix(client.agent.URL, "/events?stream=live-data")
-	historicalURL := baseURL + "/export/historical"
+	historicalURL := client.baseURL() + "/export/historical"
 
 	req, err := http.NewRequestWithContext(client.ctx, "GET", historicalURL, nil)
 	if err != nil {
@@ -1289,8 +1287,7 @@ func (s *Service) fetchAndStoreHistoricalData(client *Client) {
 
 // fetchInitialPeakStats fetches and stores initial peak bandwidth statistics from an agent
 func (c *Client) fetchInitialPeakStats() {
-	baseURL := strings.TrimSuffix(c.agent.URL, "/events?stream=live-data")
-	peaksURL := baseURL + "/stats/peaks"
+	peaksURL := c.baseURL() + "/stats/peaks"
 
 	req, err := http.NewRequestWithContext(c.ctx, "GET", peaksURL, nil)
 	if err != nil {

--- a/internal/monitor/tailscale_discovery.go
+++ b/internal/monitor/tailscale_discovery.go
@@ -340,7 +340,7 @@ func (td *TailscaleDiscovery) createAndSaveAgent(ctx context.Context, peer struc
 	Online   bool
 }, discoveryPort int) {
 	// Create agent URL with SSE endpoint using short hostname
-	agentURL := fmt.Sprintf("http://%s:%d/events?stream=live-data", peer.HostName, discoveryPort)
+	agentURL := AgentStreamURL(fmt.Sprintf("http://%s:%d", peer.HostName, discoveryPort))
 
 	// Create new agent entry
 	emptyString := ""


### PR DESCRIPTION
## Summary
- Adds an agent client module in `internal/monitor` that owns the base URL rule, the API key header, one shared HTTP client, and a timeout ceiling for each agent endpoint.
- Moves the four agent proxy handlers onto it, so their requests now carry the context of the incoming request and can no longer run without a limit.
- Closes an unconditional-close gap: response bodies now close after every successful request, in the module and in the one poller site the issue names.

## Why
- The four proxy handlers made a new `http.Client` with no timeout for each request and ignored `c.Request.Context()`. A stalled agent held the handler goroutine and its connection forever, and the browser polls two of these routes every 30 seconds.
- Nine fetch sites hand-rolled the same steps with three different timeout policies, and the stream path `/events?stream=live-data` was a magic string in many files.

Ceilings: 30 s by default, 60 s for the historical export, 5 s for the public info endpoint (the value `develop` used there). Each applies on top of the context of the caller, so cancellation by the caller still ends the request.

Two notes for the reviewer:
- The handlers keep their status codes and their database fallback branches. One drift: a request-build failure or a body-read failure now takes the cache fallback instead of a 500. Both still log at error level with the agent URL.
- The auth-header helper stays unexported. The issue asked for an export, but the only caller outside the module is the poller, which is in the same package.

Scope, as the issue sets it: the module plus the four proxy handlers. The poller keeps its own fetch code and migrates in #298. The `interface` query parameter is now escaped with `url.QueryEscape`; it was concatenated raw.

Closes #281

## Testing
- [x] Other: `go test ./...`. New table tests run against an `httptest` fake agent for endpoint paths, API key present and absent, the timeout ceiling, cancellation by the caller, and body close on a non-200 status. No test calls a real host. CI covers lint and build; the web side is untouched.
- [x] Other: field test of this build against three live agents.

Online, for all three agents: `/native`, `/system`, `/hardware` and `/peaks` each answered 200, and all panels filled. The System and Hardware tab showed the agent version, which is the `/netronome/info` value that now comes through `AgentClient.Info`. The historical export finished inside the new 60 s ceiling for each agent.

Offline, for an agent that stayed enabled while its process was stopped: `/native`, `/system` and `/hardware` answered 200 from the database, and the page showed the cached hostname, CPU, and traffic totals with the offline banner. `/peaks` answered 500, which is what `develop` does: it is the one route with no database fallback. A 502 there would have meant the new `errors.As(&StatusError)` branch was catching transport errors, so this result is the one that matters.

## Screenshots (if UI)
- None. No UI change.

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [x] AI-assisted changes reviewed and edited by a human



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved communication with monitoring agents for system, hardware, historical, peak, and version data.
  - Standardized agent URL handling, authentication, timeouts, and request cancellation.
  - Improved handling and reporting of unsuccessful agent responses.
  - Preserved reliable live-data streaming while simplifying agent connection configuration.

- **Documentation**
  - Added a definition of the Agent client to the domain vocabulary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->