### PR TITLE
fix(auth): expire PKCE verifiers and memory-only sessions

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -20,12 +20,34 @@ import (
 	"github.com/autobrr/netronome/internal/utils"
 )
 
+const (
+	// pkceVerifierTTL is the time a user has to complete a login at the identity provider.
+	pkceVerifierTTL = 15 * time.Minute
+	// pkceVerifierMax is the number of pending logins kept in memory.
+	pkceVerifierMax = 1024
+	// sessionTTL is the life of a session cookie, and of its sessionTokens entry.
+	sessionTTL = 24 * time.Hour
+)
+
+// pkceEntry is a PKCE code verifier and the time it becomes invalid.
+type pkceEntry struct {
+	verifier string
+	expires  time.Time
+}
+
+// memorySession is a session that exists only in memory, with the time it
+// becomes invalid.
+type memorySession struct {
+	claims  SessionClaims
+	expires time.Time
+}
+
 type AuthHandler struct {
 	db             database.Service
 	oidc           *auth.OIDCConfig
 	oidcConfigured bool                     // true when OIDC issuer is set in config, independent of provider state
-	sessionTokens  map[string]SessionClaims // Track valid memory sessions
-	pkceVerifiers  map[string]string        // Track PKCE code verifiers by state
+	sessionTokens  map[string]memorySession // Track valid memory sessions
+	pkceVerifiers  map[string]pkceEntry     // Track PKCE code verifiers by state
 	sessionMutex   sync.RWMutex
 	pkceMutex      sync.RWMutex
 	sessionSecret  string
@@ -37,8 +59,8 @@ func NewAuthHandler(db database.Service, oidc *auth.OIDCConfig, oidcConfigured b
 		db:             db,
 		oidc:           oidc,
 		oidcConfigured: oidcConfigured,
-		sessionTokens:  make(map[string]SessionClaims),
-		pkceVerifiers:  make(map[string]string),
+		sessionTokens:  make(map[string]memorySession),
+		pkceVerifiers:  make(map[string]pkceEntry),
 		sessionSecret:  sessionSecret,
 		whitelist:      whitelist,
 	}
@@ -98,19 +120,7 @@ func (h *AuthHandler) refreshSession(c *gin.Context, token string, claims *Sessi
 
 	// Track memory-only sessions
 	if h.sessionSecret == "" {
-		h.sessionMutex.Lock()
-		if claims != nil {
-			if token != "" && token != signedToken {
-				delete(h.sessionTokens, token)
-			}
-			h.sessionTokens[signedToken] = *claims
-		} else if _, exists := h.sessionTokens[signedToken]; !exists {
-			h.sessionTokens[signedToken] = SessionClaims{
-				Version: sessionClaimsVersion,
-				Type:    sessionTypeLocal,
-			}
-		}
-		h.sessionMutex.Unlock()
+		h.trackMemorySession(token, signedToken, claims)
 	}
 
 	logger := log.Trace().
@@ -127,7 +137,7 @@ func (h *AuthHandler) refreshSession(c *gin.Context, token string, claims *Sessi
 	c.SetCookie(
 		"session",
 		signedToken,
-		int((24 * time.Hour).Seconds()), // 24 hour expiry
+		int(sessionTTL.Seconds()),
 		"/",
 		"",       // empty domain for maximum compatibility
 		isSecure, // secure flag only if HTTPS
@@ -140,10 +150,8 @@ func (h *AuthHandler) isValidMemorySession(token string) bool {
 		return false
 	}
 
-	h.sessionMutex.RLock()
-	_, valid := h.sessionTokens[token]
-	h.sessionMutex.RUnlock()
-	return valid
+	_, ok := h.getMemorySessionClaims(token)
+	return ok
 }
 
 func (h *AuthHandler) getMemorySessionClaims(token string) (SessionClaims, bool) {
@@ -152,9 +160,50 @@ func (h *AuthHandler) getMemorySessionClaims(token string) (SessionClaims, bool)
 	}
 
 	h.sessionMutex.RLock()
-	claims, ok := h.sessionTokens[token]
+	session, ok := h.sessionTokens[token]
 	h.sessionMutex.RUnlock()
-	return claims, ok
+
+	if !ok || time.Now().After(session.expires) {
+		return SessionClaims{}, false
+	}
+	return session.claims, true
+}
+
+// trackMemorySession records a memory-only session and extends its expiry. A
+// new session first removes the sessions that expired, so that abandoned
+// browser sessions do not stay in memory. A refresh of a known session keeps
+// the request path free of the sweep.
+func (h *AuthHandler) trackMemorySession(oldToken, signedToken string, claims *SessionClaims) {
+	now := time.Now()
+
+	h.sessionMutex.Lock()
+	defer h.sessionMutex.Unlock()
+
+	existing, known := h.sessionTokens[signedToken]
+	if !known {
+		for token, session := range h.sessionTokens {
+			if now.After(session.expires) {
+				delete(h.sessionTokens, token)
+			}
+		}
+	}
+
+	session := memorySession{expires: now.Add(sessionTTL)}
+	switch {
+	case claims != nil:
+		if oldToken != "" && oldToken != signedToken {
+			delete(h.sessionTokens, oldToken)
+		}
+		session.claims = *claims
+	case known:
+		session.claims = existing.claims
+	default:
+		session.claims = SessionClaims{
+			Version: sessionClaimsVersion,
+			Type:    sessionTypeLocal,
+		}
+	}
+	h.sessionTokens[signedToken] = session
 }
 
 func (h *AuthHandler) getSessionClaims(signedToken, rawToken string) (*SessionClaims, bool) {
@@ -286,23 +335,51 @@ func sessionUsername(claims *SessionClaims) string {
 	return claims.Subject
 }
 
-// storePKCEVerifier stores a PKCE code verifier for the given state
+// storePKCEVerifier stores a PKCE code verifier for the given state. It first
+// removes the verifiers of the logins that were abandoned, then keeps the map
+// below pkceVerifierMax.
+//
+// Use it before you redirect a user to the identity provider. The callback
+// reads the verifier back with getPKCEVerifier.
 func (h *AuthHandler) storePKCEVerifier(state, codeVerifier string) {
+	now := time.Now()
+
 	h.pkceMutex.Lock()
-	h.pkceVerifiers[state] = codeVerifier
-	h.pkceMutex.Unlock()
+	defer h.pkceMutex.Unlock()
+
+	for key, entry := range h.pkceVerifiers {
+		if now.After(entry.expires) {
+			delete(h.pkceVerifiers, key)
+		}
+	}
+
+	// ponytail: random eviction under a flood of login requests. Rate limit
+	// the login route if that becomes a problem.
+	if len(h.pkceVerifiers) >= pkceVerifierMax {
+		for key := range h.pkceVerifiers {
+			delete(h.pkceVerifiers, key)
+			break
+		}
+	}
+
+	h.pkceVerifiers[state] = pkceEntry{
+		verifier: codeVerifier,
+		expires:  now.Add(pkceVerifierTTL),
+	}
 }
 
-// getPKCEVerifier retrieves and removes the PKCE code verifier for the given state
+// getPKCEVerifier retrieves and removes the PKCE code verifier for the given
+// state. An expired verifier is reported as missing.
 func (h *AuthHandler) getPKCEVerifier(state string) (string, bool) {
 	h.pkceMutex.Lock()
 	defer h.pkceMutex.Unlock()
 
-	verifier, exists := h.pkceVerifiers[state]
-	if exists {
-		delete(h.pkceVerifiers, state)
+	entry, exists := h.pkceVerifiers[state]
+	delete(h.pkceVerifiers, state)
+	if !exists || time.Now().After(entry.expires) {
+		return "", false
 	}
-	return verifier, exists
+	return entry.verifier, true
 }
 
 func (h *AuthHandler) Register(c *gin.Context) {
@@ -415,7 +492,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"access_token": sessionToken,
 		"token_type":   "Bearer",
-		"expires_in":   int((24 * time.Hour).Seconds()),
+		"expires_in":   int(sessionTTL.Seconds()),
 		"user": gin.H{
 			"id":       user.ID,
 			"username": user.Username,

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -336,8 +336,8 @@ func sessionUsername(claims *SessionClaims) string {
 }
 
 // storePKCEVerifier stores a PKCE code verifier for the given state. It first
-// removes the verifiers of the logins that were abandoned, then keeps the map
-// below pkceVerifierMax.
+// removes the verifiers of abandoned logins, then keeps the map below
+// pkceVerifierMax.
 //
 // Use it before you redirect a user to the identity provider. The callback
 // reads the verifier back with getPKCEVerifier.

--- a/internal/server/auth_expiry_test.go
+++ b/internal/server/auth_expiry_test.go
@@ -43,7 +43,7 @@ func TestPKCEVerifierExpires(t *testing.T) {
 func TestStorePKCEVerifierSweepsExpiredEntries(t *testing.T) {
 	h := NewAuthHandler(nil, nil, false, "", nil)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		h.pkceVerifiers[fmt.Sprintf("stale-%d", i)] = pkceEntry{
 			verifier: "old",
 			expires:  time.Now().Add(-time.Minute),
@@ -59,7 +59,7 @@ func TestStorePKCEVerifierSweepsExpiredEntries(t *testing.T) {
 func TestStorePKCEVerifierEnforcesCap(t *testing.T) {
 	h := NewAuthHandler(nil, nil, false, "", nil)
 
-	for i := 0; i < pkceVerifierMax+2; i++ {
+	for i := range pkceVerifierMax+2 {
 		h.storePKCEVerifier(fmt.Sprintf("state-%d", i), "verifier")
 	}
 
@@ -104,7 +104,7 @@ func TestMemorySessionExpiry(t *testing.T) {
 func TestTrackMemorySessionSweepsExpiredEntries(t *testing.T) {
 	h := NewAuthHandler(nil, nil, false, "", nil)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		h.sessionTokens[fmt.Sprintf("stale-%d", i)] = memorySession{
 			claims:  SessionClaims{Version: sessionClaimsVersion, Type: sessionTypeLocal},
 			expires: time.Now().Add(-time.Minute),

--- a/internal/server/auth_expiry_test.go
+++ b/internal/server/auth_expiry_test.go
@@ -65,7 +65,7 @@ func TestStorePKCEVerifierEnforcesCap(t *testing.T) {
 
 	assert.LessOrEqual(t, len(h.pkceVerifiers), pkceVerifierMax)
 
-	// The newest state survives the eviction of the oldest entries.
+	// The newest state survives the eviction.
 	_, ok := h.getPKCEVerifier(fmt.Sprintf("state-%d", pkceVerifierMax+1))
 	assert.True(t, ok)
 }

--- a/internal/server/auth_expiry_test.go
+++ b/internal/server/auth_expiry_test.go
@@ -59,7 +59,7 @@ func TestStorePKCEVerifierSweepsExpiredEntries(t *testing.T) {
 func TestStorePKCEVerifierEnforcesCap(t *testing.T) {
 	h := NewAuthHandler(nil, nil, false, "", nil)
 
-	for i := range pkceVerifierMax+2 {
+	for i := range pkceVerifierMax + 2 {
 		h.storePKCEVerifier(fmt.Sprintf("state-%d", i), "verifier")
 	}
 

--- a/internal/server/auth_expiry_test.go
+++ b/internal/server/auth_expiry_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2024-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/netronome/internal/auth"
+)
+
+func TestPKCEVerifierRoundTrip(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	h.storePKCEVerifier("state-1", "verifier-1")
+
+	verifier, ok := h.getPKCEVerifier("state-1")
+	require.True(t, ok)
+	assert.Equal(t, "verifier-1", verifier)
+
+	_, ok = h.getPKCEVerifier("state-1")
+	assert.False(t, ok, "verifier must be single use")
+}
+
+func TestPKCEVerifierExpires(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	h.pkceVerifiers["state-1"] = pkceEntry{
+		verifier: "verifier-1",
+		expires:  time.Now().Add(-time.Second),
+	}
+
+	_, ok := h.getPKCEVerifier("state-1")
+	assert.False(t, ok, "expired verifier must not be accepted")
+	assert.NotContains(t, h.pkceVerifiers, "state-1", "expired verifier must be removed")
+}
+
+func TestStorePKCEVerifierSweepsExpiredEntries(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	for i := 0; i < 10; i++ {
+		h.pkceVerifiers[fmt.Sprintf("stale-%d", i)] = pkceEntry{
+			verifier: "old",
+			expires:  time.Now().Add(-time.Minute),
+		}
+	}
+
+	h.storePKCEVerifier("fresh", "verifier")
+
+	assert.Len(t, h.pkceVerifiers, 1, "abandoned logins must not accumulate")
+	assert.Contains(t, h.pkceVerifiers, "fresh")
+}
+
+func TestStorePKCEVerifierEnforcesCap(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	for i := 0; i < pkceVerifierMax+2; i++ {
+		h.storePKCEVerifier(fmt.Sprintf("state-%d", i), "verifier")
+	}
+
+	assert.LessOrEqual(t, len(h.pkceVerifiers), pkceVerifierMax)
+
+	// The newest state survives the eviction of the oldest entries.
+	_, ok := h.getPKCEVerifier(fmt.Sprintf("state-%d", pkceVerifierMax+1))
+	assert.True(t, ok)
+}
+
+func TestMemorySessionExpiry(t *testing.T) {
+	tests := []struct {
+		name    string
+		expires time.Time
+		valid   bool
+	}{
+		{name: "before expiry", expires: time.Now().Add(time.Hour), valid: true},
+		{name: "after expiry", expires: time.Now().Add(-time.Second), valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewAuthHandler(nil, nil, false, "", nil)
+
+			token := auth.MemoryOnlyPrefix + "session-token"
+			h.sessionTokens[token] = memorySession{
+				claims:  SessionClaims{Version: sessionClaimsVersion, Type: sessionTypeLocal},
+				expires: tt.expires,
+			}
+
+			assert.Equal(t, tt.valid, h.isValidMemorySession(token))
+
+			claims, ok := h.getMemorySessionClaims(token)
+			require.Equal(t, tt.valid, ok)
+			if tt.valid {
+				assert.Equal(t, sessionTypeLocal, claims.Type)
+			}
+		})
+	}
+}
+
+func TestTrackMemorySessionSweepsExpiredEntries(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	for i := 0; i < 10; i++ {
+		h.sessionTokens[fmt.Sprintf("stale-%d", i)] = memorySession{
+			claims:  SessionClaims{Version: sessionClaimsVersion, Type: sessionTypeLocal},
+			expires: time.Now().Add(-time.Minute),
+		}
+	}
+
+	h.trackMemorySession("", auth.MemoryOnlyPrefix+"fresh", nil)
+
+	assert.Len(t, h.sessionTokens, 1, "expired memory sessions must not accumulate")
+	assert.True(t, h.isValidMemorySession(auth.MemoryOnlyPrefix+"fresh"))
+}
+
+func TestTrackMemorySessionExtendsExpiry(t *testing.T) {
+	h := NewAuthHandler(nil, nil, false, "", nil)
+
+	token := auth.MemoryOnlyPrefix + "session-token"
+	h.sessionTokens[token] = memorySession{
+		claims:  SessionClaims{Version: sessionClaimsVersion, Type: sessionTypeOIDC, Username: "alice"},
+		expires: time.Now().Add(time.Minute),
+	}
+
+	h.trackMemorySession("", token, nil)
+
+	entry := h.sessionTokens[token]
+	assert.Equal(t, "alice", entry.claims.Username, "existing claims must survive a refresh")
+	assert.Greater(t, time.Until(entry.expires), time.Hour, "refresh must extend the expiry")
+}


### PR DESCRIPTION
## Summary
- Give each PKCE verifier and each memory-only session an expiry, sweep the expired entries when a new entry comes in, and cap the verifier map at 1024.
- Replace the three hardcoded `24 * time.Hour` values with one `sessionTTL` constant, so the cookie and its map entry cannot drift apart.

## Why
- Every request to the public `/api/auth/oidc/login` stored a verifier that only a matching callback removed. An abandoned login kept its entry for the life of the process.

## Testing
- [ ] `pnpm -C web lint`
- [ ] `pnpm -C web build`
- [x] Other: local field test

Tested `e488d1d` with a fake OIDC provider and loopback-only networking:

- OIDC and local login, session refresh, logout, and callback replay rejection passed.
- A burst of 1,050 pending logins retained exactly 1,024 usable verifiers. The 26 evicted callbacks failed before token exchange.
- Signed sessions passed provider refresh and restart checks, including a configured base URL.
- Expiration and refresh checks passed with temporary limits of 2 seconds for PKCE and 6 seconds for sessions. The production 15-minute and 24-hour waits were not tested.

All test processes, listeners, credentials, and files were removed. Logs stayed quiet for more than 61 seconds. CI covers automated tests. No web changes.

## Checklist
- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [x] AI-assisted changes reviewed and edited by a human

Closes #283

### Note on the data race in the issue comment
The comment reports that `internal/server/auth.go:533` deletes from `sessionTokens` without the lock. That is not correct: `develop:internal/server/auth.go:531-535` already holds `sessionMutex.Lock()` around the delete. This PR changes nothing there.

### Residuals
- `sessionTokens` gets the expiry but no cap. Growth needs authenticated logins and is bounded by 24 hours of them.
- Under a flood of more than 1024 login requests inside the 15-minute TTL, the cap can drop a legitimate pending login. Any cap has this ceiling. A `ponytail:` comment names it and points at a rate limit on the login route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now expire automatically after 24 hours, preventing stale sessions from accumulating.
  * Session refreshes correctly extend the session lifetime while preserving existing claims.
  * Login verification data expires after 15 minutes, is single-use, and is capped to prevent excessive pending login attempts.
  * Expired authentication data is automatically cleaned up, improving reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
