### PR TITLE
docs: make release download portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,17 @@ Get Netronome running in under 5 minutes:
 
 Download prebuilt binaries from the [Releases page](https://github.com/autobrr/netronome/releases/latest).
 
-### Option 2: One-liner Installation
+### Option 2: Download with curl
+
+Use this on Linux, macOS, or FreeBSD with `curl` and `tar` installed.
 
 ```bash
-# Download latest release
-wget $(curl -s https://api.github.com/repos/autobrr/netronome/releases/latest | grep download | grep linux_x86_64 | cut -d\" -f4)
-tar -C /usr/local/bin -xzf netronome*.tar.gz
+arch=$(uname -m | sed 's/^aarch64$/arm64/; s/^amd64$/x86_64/; s/^armv[67]l$/arm/')
+url=$(curl -fsSL https://api.github.com/repos/autobrr/netronome/releases/latest | grep -i "browser_download_url.*_$(uname -s)_${arch}\.tar\.gz\"" | cut -d'"' -f4)
+curl -fL "$url" -o netronome.tar.gz &&
+  tar -C /usr/local/bin -xzf netronome.tar.gz
 
-# Generate default config
+# Generate the default configuration
 netronome generate-config
 
 # Start the server
@@ -183,10 +186,7 @@ Notes:
 
 1. **Download and Install**
 
-   ```bash
-   wget $(curl -s https://api.github.com/repos/autobrr/netronome/releases/latest | grep download | grep linux_x86_64 | cut -d\" -f4)
-   tar -C /usr/local/bin -xzf netronome*.tar.gz
-   ```
+   Use the [quick-start download commands](#option-2-download-with-curl).
 
 2. **Create Systemd Service** (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,15 @@ Download prebuilt binaries from the [Releases page](https://github.com/autobrr/n
 ### Option 2: Download with curl
 
 Use this on Linux, macOS, or FreeBSD with `curl` and `tar` installed.
+The extraction step uses `sudo` to write to `/usr/local/bin`. If you run as root, omit `sudo`.
 
 ```bash
 arch=$(uname -m | sed 's/^aarch64$/arm64/; s/^amd64$/x86_64/; s/^armv[67]l$/arm/')
 url=$(curl -fsSL https://api.github.com/repos/autobrr/netronome/releases/latest | grep -i "browser_download_url.*_$(uname -s)_${arch}\.tar\.gz\"" | cut -d'"' -f4)
 curl -fL "$url" -o netronome.tar.gz &&
-  tar -C /usr/local/bin -xzf netronome.tar.gz
-
-# Generate the default configuration
-netronome generate-config
-
-# Start the server
-netronome serve
+  sudo tar -C /usr/local/bin -xzf netronome.tar.gz &&
+  netronome generate-config &&
+  netronome serve
 ```
 
 Open `http://localhost:7575` in your browser and create your account through the registration page. For Docker users, see the [Docker Installation](#docker-installation) section.


### PR DESCRIPTION
## Summary

Use one portable download example with `sudo` for extraction and stop setup if installation fails.

Closes #300.

## Why

The previous examples always downloaded Linux x86_64 and did not stop startup after an installation failure.

## Testing

- [ ] `pnpm -C web lint`
- [ ] `pnpm -C web build`
- [x] Other:

Local offline checks covered platform selection. Mocked runs in Bash and sh stopped on download, permission, extraction, and configuration failures. Native installations remain untested. Backend and frontend tests were skipped because neither changed.

## Screenshots (if UI)

Not applicable.

## Checklist

- [x] Diff is scoped to the issue (no unrelated changes)
- [x] No new lockfiles (pnpm only)
- [x] No generated/dist files committed
- [ ] AI-assisted changes reviewed and edited by a human


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Quick Start installation instructions with portable, OS- and architecture-aware curl commands.
  - Added guidance for extracting releases with elevated permissions, including use without `sudo` when running as root.
  - Improved command sequencing so later setup steps run only after downloads and extraction succeed.
  - Simplified the Linux installation section by linking to the shared Quick Start instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->